### PR TITLE
Upgrade gitlab runner and docker machine

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Add parameter for docker machine version
+- Upgrade default gitlab runner version to 11.0.0
+- Upgrade default docker-machine version to 0.15.0
 
 ## [1.0.2] - 2018-06-22
 ### Changed

--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2018-06-22
+### Changed
+- Add link to blog for a detailed setup description
+
 ## [1.0.1] - 2018-06-21
 ### Changed
 - Moved example so it is shown in the registry
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update default AMI's to The latest Amazon Linux AMI 2017.09.1 - released on 2018-01-17.
 - Minor updates in the example
 
-[Unreleased]: https://github.com/npalm/terraform-aws-gitlab-runner/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/npalm/terraform-aws-gitlab-runner/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/npalm/terraform-aws-gitlab-runner/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/npalm/terraform-aws-gitlab-runner/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/npalm/terraform-aws-gitlab-runner/compare/0.2.0...1.0.0

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ module "gitlab-runner" {
 
 All variables and defaults:
 
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | amazon_optimized_amis | AMI map per region-zone for the gitlab-runner instance AMI. | map | `<map>` | no |
@@ -83,9 +84,10 @@ All variables and defaults:
 | docker_machine_instance_type | Instance type used for the instances hosting docker-machine. | string | `m4.large` | no |
 | docker_machine_spot_price_bid | Spot price bid. | string | `0.04` | no |
 | docker_machine_user | User name for the user to create spot instances to host docker-machine. | string | `docker-machine` | no |
+| docker_machine_version | Version of docker-machine. | string | `0.15.0` | no |
 | enable_cloudwatch_logging | Enable or disable the CloudWatch logging. | string | `1` | no |
 | environment | A name that identifies the environment, will used as prefix and for tagging. | string | - | yes |
-| gitlab_runner_version | Version for the gitlab runner. | string | `10.8.0` | no |
+| gitlab_runner_version | Version for the gitlab runner. | string | `11.0.0` | no |
 | instance_type | Instance type used for the gitlab-runner. | string | `t2.micro` | no |
 | runners_concurrent | Concurrent value for the runners, will be used in the runner config.toml | string | `10` | no |
 | runners_gitlab_url | URL of the gitlab instance to connect to. | string | - | yes |

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,9 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-output "account_id" {
-  value = "${data.aws_caller_identity.current.account_id}"
-}
-
 resource "aws_s3_bucket" "build_cache" {
   bucket = "${data.aws_caller_identity.current.account_id}-gitlab-runner-cache"
   acl    = "private"

--- a/examples/runner/terraform.tfvars
+++ b/examples/runner/terraform.tfvars
@@ -5,7 +5,8 @@ environment = "ci"
 aws_region = "eu-west-1"
 
 # Add the following variables:
-# runner_name = ""
-# gitlab_url = ""
-# runner_token = ""
+runner_name = ""
 
+gitlab_url = ""
+
+runner_token = ""

--- a/main.tf
+++ b/main.tf
@@ -88,8 +88,9 @@ data "template_file" "gitlab_runner" {
   template = "${file("${path.module}/template/gitlab-runner.tpl")}"
 
   vars {
-    gitlab_runner_version = "${var.gitlab_runner_version}"
-    runners_config        = "${data.template_file.runners.rendered}"
+    gitlab_runner_version  = "${var.gitlab_runner_version}"
+    docker_machine_version = "${var.docker_machine_version}"
+    runners_config         = "${data.template_file.runners.rendered}"
   }
 }
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -7,7 +7,7 @@ EOF
 
 curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash
 yum install gitlab-runner-${gitlab_runner_version} -y
-curl -L https://github.com/docker/machine/releases/download/v0.13.0/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
+curl -L https://github.com/docker/machine/releases/download/v${docker_machine_version}/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
   chmod +x /tmp/docker-machine && \
   cp /tmp/docker-machine /usr/local/bin/docker-machine && \
   ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "docker_machine_spot_price_bid" {
   default     = "0.04"
 }
 
+variable "docker_machine_version" {
+  description = "Version of docker-machine."
+  default     = "0.15.0"
+}
+
 variable "runners_name" {
   description = "Name of the runner, will be used in the runner config.toml"
   type        = "string"
@@ -128,7 +133,7 @@ variable "cache_expiration_days" {
 variable "gitlab_runner_version" {
   description = "Version for the gitlab runner."
   type        = "string"
-  default     = "10.8.0"
+  default     = "11.0.0"
 }
 
 variable "enable_cloudwatch_logging" {


### PR DESCRIPTION
- Add parameter for docker machine version
- Upgrade default gitlab runner version to 11.0.0
- Upgrade default docker-machine version to 0.15.0
