### PR TITLE
Add `cache_bucket_prefix`, to allow for unique bucket names

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ All variables and defaults:
 | -----------------------------     | ------------------------------------------------------------------------------------------------------------------- | :----: | :--------------: | :------: |
 | amazon_optimized_amis             | AMI map per region-zone for the gitlab-runner instance AMI.                                                         | map    | `<map>`          | no       |
 | aws_region                        | AWS region.                                                                                                         | string | -                | yes      |
+| cache_bucket_prefix               | Prefix for s3 cache bucket name.                                                                                    | string | ""               | no       |
 | cache_expiration_days             | Number of days before cache objects expires.                                                                        | string | `1`              | no       |
 | cache_user                        | User name of the user to create to write and read to the s3 cache.                                                  | string | `cache_user`     | no       |
 | docker_machine_instance_type      | Instance type used for the instances hosting docker-machine.                                                        | string | `m4.large`       | no       |

--- a/README.md
+++ b/README.md
@@ -102,42 +102,42 @@ module "gitlab-runner" {
 
 All variables and defaults:
 
-| Name                          | Description                                                                                                         |  Type  |     Default      | Required |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | :----: | :--------------: | :------: |
-| amazon_optimized_amis         | AMI map per region-zone for the gitlab-runner instance AMI.                                                         |  map   |     `<map>`      |    no    |
-| aws_region                    | AWS region.                                                                                                         | string |        -         |   yes    |
-| cache_expiration_days         | Number of days before cache objects expires.                                                                        | string |       `1`        |    no    |
-| cache_user                    | User name of the user to create to write and read to the s3 cache.                                                  | string |   `cache_user`   |    no    |
-| docker_machine_instance_type  | Instance type used for the instances hosting docker-machine.                                                        | string |    `m4.large`    |    no    |
-| docker_machine_spot_price_bid | Spot price bid.                                                                                                     | string |      `0.04`      |    no    |
-| docker_machine_user           | User name for the user to create spot instances to host docker-machine.                                             | string | `docker-machine` |    no    |
-| docker_machine_version        | Version of docker-machine.                                                                                          | string |     `0.15.0`     |    no    |
-| enable_cloudwatch_logging     | Enable or disable the CloudWatch logging.                                                                           | string |       `1`        |    no    |
-| environment                   | A name that identifies the environment, will used as prefix and for tagging.                                        | string |        -         |   yes    |
-| gitlab_runner_version         | Version for the gitlab runner.                                                                                      | string |     `11.3.1`     |    no    |
-| instance_type                 | Instance type used for the gitlab-runner.                                                                           | string |    `t2.micro`    |    no    |
-| runners_concurrent            | Concurrent value for the runners, will be used in the runner config.toml                                            | string |       `10`       |    no    |
-| runners_gitlab_url            | URL of the gitlab instance to connect to.                                                                           | string |        -         |   yes    |
-| runners_idle_count            | Idle count of the runners, will be used in the runner config.toml                                                   | string |       `0`        |    no    |
-| runners_idle_time             | Idle time of the runners, will be used in the runner config.toml                                                    | string |      `600`       |    no    |
-| runners_limit                 | Limit for the runners, will be used in the runner config.toml                                                       | string |       `0`        |    no    |
-| runners_monitoring            | Enable detailed cloudwatch monitoring for spot instances.                                                           | string |     `false`      |    no    |
-| runners_name                  | Name of the runner, will be used in the runner config.toml                                                          | string |        -         |   yes    |
-| runners_off_peak_idle_count   | Off peak idle count of the runners, will be used in the runner config.toml.                                         | string |       `0`        |    no    |
-| runners_off_peak_idle_time    | Off peak idle time of the runners, will be used in the runner config.toml.                                          | string |       `0`        |    no    |
-| runners_off_peak_periods      | Off peak periods of the runners, will be used in the runner config.toml.                                            | string |     `` | no      |
-| runners_off_peak_timezone     | Off peak idle time zone of the runners, will be used in the runner config.toml.                                     | string |     `` | no      |
-| runners_privilled             | Runners will run in privilled mode, will be used in the runner config.toml                                          | string |      `true`      |    no    |
-| runners_root_size             | Runnner instance root size in GB.                                                                                   | string |       `16`       |    no    |
-| runners_iam_instance_profile_name  | Instance profile to attach to the runners                                                                      | string |        ""        |    no    |
-| runners_pre_build_script      | Script to execute in the pipeline just before the build.                                                            | string |        ""        |    no    |
-| runners_use_private_address   | Restrict runners to use only private address                                                                        | string |      `true`      |    no    |
-| runners_token                 | Token for the runner, will be used in the runner config.toml                                                        | string |        -         |   yes    |
-| ssh_public_key                | Public SSH key used for the gitlab-runner ec2 instance.                                                             | string |        -         |   yes    |
-| subnet_id_gitlab_runner       | Subnet used for hosting the gitlab-runner.                                                                          | string |        -         |   yes    |
-| subnet_id_runners             | Subnet used to hosts the docker-machine runners.                                                                    | string |        -         |   yes    |
-| tags                          | Map of tags that will be added to created resources. By default resources will be taggen with name and environemnt. |  map   |     `<map>`      |    no    |
-| vpc_id                        | The VPC that is used for the instances.                                                                             | string |        -         |   yes    |
+| Name                              | Description                                                                                                         | Type   | Default          | Required |
+| -----------------------------     | ------------------------------------------------------------------------------------------------------------------- | :----: | :--------------: | :------: |
+| amazon_optimized_amis             | AMI map per region-zone for the gitlab-runner instance AMI.                                                         | map    | `<map>`          | no       |
+| aws_region                        | AWS region.                                                                                                         | string | -                | yes      |
+| cache_expiration_days             | Number of days before cache objects expires.                                                                        | string | `1`              | no       |
+| cache_user                        | User name of the user to create to write and read to the s3 cache.                                                  | string | `cache_user`     | no       |
+| docker_machine_instance_type      | Instance type used for the instances hosting docker-machine.                                                        | string | `m4.large`       | no       |
+| docker_machine_spot_price_bid     | Spot price bid.                                                                                                     | string | `0.04`           | no       |
+| docker_machine_user               | User name for the user to create spot instances to host docker-machine.                                             | string | `docker-machine` | no       |
+| docker_machine_version            | Version of docker-machine.                                                                                          | string | `0.15.0`         | no       |
+| enable_cloudwatch_logging         | Enable or disable the CloudWatch logging.                                                                           | string | `1`              | no       |
+| environment                       | A name that identifies the environment, will used as prefix and for tagging.                                        | string | -                | yes      |
+| gitlab_runner_version             | Version for the gitlab runner.                                                                                      | string | `11.3.1`         | no       |
+| instance_type                     | Instance type used for the gitlab-runner.                                                                           | string | `t2.micro`       | no       |
+| runners_concurrent                | Concurrent value for the runners, will be used in the runner config.toml                                            | string | `10`             | no       |
+| runners_gitlab_url                | URL of the gitlab instance to connect to.                                                                           | string | -                | yes      |
+| runners_idle_count                | Idle count of the runners, will be used in the runner config.toml                                                   | string | `0`              | no       |
+| runners_idle_time                 | Idle time of the runners, will be used in the runner config.toml                                                    | string | `600`            | no       |
+| runners_limit                     | Limit for the runners, will be used in the runner config.toml                                                       | string | `0`              | no       |
+| runners_monitoring                | Enable detailed cloudwatch monitoring for spot instances.                                                           | string | `false`          | no       |
+| runners_name                      | Name of the runner, will be used in the runner config.toml                                                          | string | -                | yes      |
+| runners_off_peak_idle_count       | Off peak idle count of the runners, will be used in the runner config.toml.                                         | string | `0`              | no       |
+| runners_off_peak_idle_time        | Off peak idle time of the runners, will be used in the runner config.toml.                                          | string | `0`              | no       |
+| runners_off_peak_periods          | Off peak periods of the runners, will be used in the runner config.toml.                                            | string | ``               | no       |
+| runners_off_peak_timezone         | Off peak idle time zone of the runners, will be used in the runner config.toml.                                     | string | ``               | no       |
+| runners_privilled                 | Runners will run in privilled mode, will be used in the runner config.toml                                          | string | `true`           | no       |
+| runners_root_size                 | Runnner instance root size in GB.                                                                                   | string | `16`             | no       |
+| runners_iam_instance_profile_name | Instance profile to attach to the runners                                                                           | string | ""               | no       |
+| runners_pre_build_script          | Script to execute in the pipeline just before the build.                                                            | string | ""               | no       |
+| runners_use_private_address       | Restrict runners to use only private address                                                                        | string | `true`           | no       |
+| runners_token                     | Token for the runner, will be used in the runner config.toml                                                        | string | -                | yes      |
+| ssh_public_key                    | Public SSH key used for the gitlab-runner ec2 instance.                                                             | string | -                | yes      |
+| subnet_id_gitlab_runner           | Subnet used for hosting the gitlab-runner.                                                                          | string | -                | yes      |
+| subnet_id_runners                 | Subnet used to hosts the docker-machine runners.                                                                    | string | -                | yes      |
+| tags                              | Map of tags that will be added to created resources. By default resources will be taggen with name and environemnt. | map    | `<map>`          | no       |
+| vpc_id                            | The VPC that is used for the instances.                                                                             | string | -                | yes      |
 
 ## Example
 

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "build_cache" {
-  bucket = "${data.aws_caller_identity.current.account_id}-gitlab-runner-cache"
+  bucket = "${var.cache_bucket_prefix}${data.aws_caller_identity.current.account_id}-gitlab-runner-cache"
   acl    = "private"
 
   tags = "${local.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,12 @@ variable "cache_user" {
   default     = "cache_user"
 }
 
+variable "cache_bucket_prefix" {
+  description = "Prefix for s3 cache bucket name."
+  type        = "string"
+  default     = ""
+}
+
 variable "cache_expiration_days" {
   description = "Number of days before cache objects expires."
   default     = 1


### PR DESCRIPTION
Sometimes you may want to run more than one of these instances per AWS account :)  Allowing an optional prefix enables unique bucket names to be configured, without breaking existing installations.
