### PR TITLE
Add pre/post install user-data snippets for runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ All variables and defaults:
 | environment                       | A name that identifies the environment, will used as prefix and for tagging.                                        | string | -                | yes      |
 | gitlab_runner_version             | Version for the gitlab runner.                                                                                      | string | `11.3.1`         | no       |
 | instance_type                     | Instance type used for the gitlab-runner.                                                                           | string | `t2.micro`       | no       |
+| userdata_pre_install              | User-data script snippet to insert before runner install                                                            | string | ""               | no       |
+| userdata_post_install             | User-data script snippet to insert after runner install                                                             | string | ""               | no       |
 | runners_concurrent                | Concurrent value for the runners, will be used in the runner config.toml                                            | string | `10`             | no       |
 | runners_gitlab_url                | URL of the gitlab instance to connect to.                                                                           | string | -                | yes      |
 | runners_idle_count                | Idle count of the runners, will be used in the runner config.toml                                                   | string | `0`              | no       |

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ All variables and defaults:
 | environment                       | A name that identifies the environment, will used as prefix and for tagging.                                        | string | -                | yes      |
 | gitlab_runner_version             | Version for the gitlab runner.                                                                                      | string | `11.3.1`         | no       |
 | instance_type                     | Instance type used for the gitlab-runner.                                                                           | string | `t2.micro`       | no       |
-| userdata_pre_install              | User-data script snippet to insert before runner install                                                            | string | ""               | no       |
-| userdata_post_install             | User-data script snippet to insert after runner install                                                             | string | ""               | no       |
+| userdata_pre_install              | User-data script snippet to insert before gitlab-runner install                                                     | string | ""               | no       |
+| userdata_post_install             | User-data script snippet to insert after gitlab-runner install                                                      | string | ""               | no       |
 | runners_concurrent                | Concurrent value for the runners, will be used in the runner config.toml                                            | string | `10`             | no       |
 | runners_gitlab_url                | URL of the gitlab instance to connect to.                                                                           | string | -                | yes      |
 | runners_idle_count                | Idle count of the runners, will be used in the runner config.toml                                                   | string | `0`              | no       |

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,8 @@ data "template_file" "gitlab_runner" {
     gitlab_runner_version  = "${var.gitlab_runner_version}"
     docker_machine_version = "${var.docker_machine_version}"
     runners_config         = "${data.template_file.runners.rendered}"
+    pre_install            = "${var.userdata_pre_install}"
+    post_install           = "${var.userdata_post_install}"
   }
 }
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -5,6 +5,8 @@ ${runners_config}
 
 EOF
 
+${pre_install}
+
 curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash
 yum install gitlab-runner-${gitlab_runner_version} -y
 curl -L https://github.com/docker/machine/releases/download/v${docker_machine_version}/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
@@ -12,6 +14,7 @@ curl -L https://github.com/docker/machine/releases/download/v${docker_machine_ve
   cp /tmp/docker-machine /usr/local/bin/docker-machine && \
   ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine
 
+${post_install}
 
 service gitlab-runner restart
 chkconfig gitlab-runner on

--- a/variables.tf
+++ b/variables.tf
@@ -161,13 +161,13 @@ variable "runners_pre_build_script" {
 }
 
 variable "userdata_pre_install" {
-  description = "User-data script snippet to insert before runner install"
+  description = "User-data script snippet to insert before gitlab-runner install"
   type        = "string"
   default     = ""
 }
 
 variable "userdata_post_install" {
-  description = "User-data script snippet to insert after runner install"
+  description = "User-data script snippet to insert after gitlab-runner install"
   type        = "string"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -160,6 +160,18 @@ variable "runners_pre_build_script" {
   default     = ""
 }
 
+variable "userdata_pre_install" {
+  description = "User-data script snippet to insert before runner install"
+  type        = "string"
+  default     = ""
+}
+
+variable "userdata_post_install" {
+  description = "User-data script snippet to insert after runner install"
+  type        = "string"
+  default     = ""
+}
+
 variable "runners_use_private_address" {
   description = "Restrict runners to use only private address"
   default     = "true"


### PR DESCRIPTION
This commit introduces two new variables, intended to be used to allow
scriptlets to be inserted before and after the runner install (but
before the runner is started) in the user-data configuration.