### PR TITLE
Configurable docker image for runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All variables and defaults:
 | runners_off_peak_idle_time        | Off peak idle time of the runners, will be used in the runner config.toml.                                          | string | `0`              | no       |
 | runners_off_peak_periods          | Off peak periods of the runners, will be used in the runner config.toml.                                            | string | ``               | no       |
 | runners_off_peak_timezone         | Off peak idle time zone of the runners, will be used in the runner config.toml.                                     | string | ``               | no       |
+| runners_image                     | Image to run builds, will be used in the runner config.toml                                                         | string | `docker:18.03.1-ce`           | no       |
 | runners_privilled                 | Runners will run in privilled mode, will be used in the runner config.toml                                          | string | `true`           | no       |
 | runners_root_size                 | Runnner instance root size in GB.                                                                                   | string | `16`             | no       |
 | runners_iam_instance_profile_name | Instance profile to attach to the runners                                                                           | string | ""               | no       |

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,7 @@ data "template_file" "runners" {
     runners_token                     = "${var.runners_token}"
     runners_limit                     = "${var.runners_limit}"
     runners_concurrent                = "${var.runners_concurrent}"
+    runners_image                     = "${var.runners_image}"
     runners_privilled                 = "${var.runners_privilled}"
     runners_idle_count                = "${var.runners_idle_count}"
     runners_idle_time                 = "${var.runners_idle_time}"

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -10,7 +10,7 @@ check_interval = 0
   limit = ${runners_limit}
   [runners.docker]
     tls_verify = false
-    image = "docker:18.03.1-ce"
+    image = "${runners_image}"
     privileged = ${runners_privilled}
     disable_cache = false
     volumes = ["/cache"]

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,12 @@ variable "runners_idle_count" {
   default     = 0
 }
 
+variable "runners_image" {
+  description = "Image to run builds, will be used in the runner config.toml"
+  type        = "string"
+  default     = "docker:18.03.1-ce"
+}
+
 variable "runners_privilled" {
   description = "Runners will run in privilled mode, will be used in the runner config.toml"
   type        = "string"


### PR DESCRIPTION
Hi, @npalm!

This PR introduces configurable docker image for runners.

In our case we need the ability to use custom images, because we work with private docker registries and need to configure credential helpers to perform pulls from them. To handle this, I've added the variable `runners_image` with default value `docker:18.03.1-ce`. So without setting this variable everything should work as before.