### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Changed: The variable `amazon_optimized_amis` is removed an replaced by a filter to select the AMI. To use the default of the latest AMI set the filter `ami_filter` to `amzn-ami-hvm-2018.03.0.20180622-x86_64-ebs`.
+- Added: Option to set docker machine options via `docker_machine_optionns`.
+- Added: Several output variables.
+
 
 ## [1.8.0] - 2018-12-30
 - Changed: Updated default docker-machine version to 0.16.0

--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ All variables and defaults:
 | cache_expiration_days | Number of days before cache objects expires. | string | `1` | no |
 | cache_user | User name of the user to create to write and read to the s3 cache. | string | `cache_user` | no |
 | docker_machine_instance_type | Instance type used for the instances hosting docker-machine. | string | `m4.large` | no |
+| docker_machine_options | Additional to set options for docker machien. Each element of the list should be key and value. E.g. '["--amazonec2-zone=a"]' | list | `<list>` | no |
 | docker_machine_spot_price_bid | Spot price bid. | string | `0.04` | no |
 | docker_machine_user | User name for the user to create spot instances to host docker-machine. | string | `docker-machine` | no |
-| docker_machine_version | Version of docker-machine. | string | `0.15.0` | no |
+| docker_machine_version | Version of docker-machine. | string | `0.16.0` | no |
 | enable_cloudwatch_logging | Enable or disable the CloudWatch logging. | string | `1` | no |
 | environment | A name that identifies the environment, will used as prefix and for tagging. | string | - | yes |
-| gitlab_runner_version | Version for the gitlab runner. | string | `11.3.1` | no |
+| gitlab_runner_version | Version for the gitlab runner. | string | `11.6.0` | no |
 | instance_type | Instance type used for the gitlab-runner. | string | `t2.micro` | no |
 | runners_concurrent | Concurrent value for the runners, will be used in the runner config.toml | string | `10` | no |
 | runners_gitlab_url | URL of the gitlab instance to connect to. | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ module "gitlab-runner" {
 
 All variables and defaults:
 
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow_iam_service_linked_role_creation | Attach policy to runner instance to create service linked roles. | string | `true` | no |
@@ -118,6 +119,7 @@ All variables and defaults:
 | enable_cloudwatch_logging | Enable or disable the CloudWatch logging. | string | `1` | no |
 | environment | A name that identifies the environment, will used as prefix and for tagging. | string | - | yes |
 | gitlab_runner_version | Version for the gitlab runner. | string | `11.6.0` | no |
+| instance_role_json | Instance role json to override the default. | string | `` | no |
 | instance_type | Instance type used for the gitlab-runner. | string | `t2.micro` | no |
 | runners_concurrent | Concurrent value for the runners, will be used in the runner config.toml | string | `10` | no |
 | runners_gitlab_url | URL of the gitlab instance to connect to. | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ gitlab_url   = "GIT_LAB_URL"
 runner_token  = "RUNNER_TOKEN"
 ```
 
+The base image used to host the GitLab Runner agent is the latest available Amazon Linux HVM EBS AMI. In previous version of the module an hard coded list of AMI per region was available. This list is replaced by a search filter to find the latest AMI. By setting the filter for example to `amzn-ami-hvm-2018.03.0.20180622-x86_64-ebs` you can lock the version of the AMI.
+
+
 ### Usage module.
 
 ```hcl
@@ -150,6 +153,13 @@ All variables and defaults:
 | userdata_post_install | User-data script snippet to insert after gitlab-runner install | string | `` | no |
 | userdata_pre_install | User-data script snippet to insert before gitlab-runner install | string | `` | no |
 | vpc_id | The VPC that is used for the instances. | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| runner_as_group_name | Name of the autoscaling group for the gitlab-runner instance |
+| runner_cache_bucket_arn | ARN of the S3 for the build cache. |
 
 ## Example
 

--- a/main.tf
+++ b/main.tf
@@ -152,10 +152,18 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   tags = ["${data.null_data_source.tags.*.outputs}"]
 }
 
+data "aws_ami" "runner" {
+  most_recent = "true"
+
+  filter = "${var.ami_filter}"
+
+  owners = ["${var.ami_owners}"]
+}
+
 resource "aws_launch_configuration" "gitlab_runner_instance" {
   security_groups      = ["${aws_security_group.runner.id}"]
   key_name             = "${aws_key_pair.key.key_name}"
-  image_id             = "${lookup(var.amazon_optimized_amis, var.aws_region)}"
+  image_id             = "${data.aws_ami.runner.id}"
   user_data            = "${data.template_file.user_data.rendered}"
   instance_type        = "${var.instance_type}"
   iam_instance_profile = "${aws_iam_instance_profile.instance.name}"

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,11 @@ data "template_file" "gitlab_runner" {
   }
 }
 
+locals {
+  // Convert list to a string seperated and prepend by a comma
+  docker_machine_options_string = "${format(",%s", join(",", formatlist("%q", var.docker_machine_options)))}"
+}
+
 data "template_file" "runners" {
   template = "${file("${path.module}/template/runner-config.tpl")}"
 
@@ -104,6 +109,8 @@ data "template_file" "runners" {
     runners_spot_price_bid      = "${var.docker_machine_spot_price_bid}"
     runners_security_group_name = "${aws_security_group.docker_machine.name}"
     runners_monitoring          = "${var.runners_monitoring}"
+
+    docker_machine_options = "${length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string}"
 
     runners_name                      = "${var.runners_name}"
     runners_token                     = "${var.runners_token}"

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_iam_instance_profile" "instance" {
 }
 
 data "template_file" "instance_role_trust_policy" {
-  template = "${file("${path.module}/policies/instance-role-trust-policy.json")}"
+  template = "${length(var.instance_role_json) > 0 ? var.instance_role_json : file("${path.module}/policies/instance-role-trust-policy.json")}"
 }
 
 resource "aws_iam_role" "instance" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "runner_as_group_name" {
+  description = "Name of the autoscaling group for the gitlab-runner instance"
+  value       = "${aws_autoscaling_group.gitlab_runner_instance.name}"
+}
+
+output "runner_cache_bucket_arn" {
+  description = "ARN of the S3 for the build cache."
+  value       = "${aws_s3_bucket.build_cache.arn}"
+}

--- a/policies/cache.json
+++ b/policies/cache.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "allowGitLabRunnersAccessCache",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:GetObject",
+        "s3:GetObjectAcl"
+      ],
+      "Resource": [
+        "${s3_cache_arn}/*"
+      ]
+    }
+  ]
+}

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -31,7 +31,20 @@ check_interval = 0
     IdleTime = ${runners_idle_time}
     MachineDriver = "amazonec2"
     MachineName = "runner-%s"
-    MachineOptions = ["amazonec2-instance-type=${runners_instance_type}", "amazonec2-region=${aws_region}", "amazonec2-vpc-id=${runners_vpc_id}", "amazonec2-subnet-id=${runners_subnet_id}", "amazonec2-private-address-only=${runners_use_private_address}", "amazonec2-request-spot-instance=true", "amazonec2-spot-price=${runners_spot_price_bid}", "amazonec2-security-group=${runners_security_group_name}", "amazonec2-tags=environment,${environment}", "amazonec2-monitoring=${runners_monitoring}", "amazonec2-root-size=${runners_root_size}", "amazonec2-iam-instance-profile=${runners_iam_instance_profile_name}"]
+    MachineOptions = [
+      "amazonec2-instance-type=${runners_instance_type}",
+      "amazonec2-region=${aws_region}",
+      "amazonec2-vpc-id=${runners_vpc_id}",
+      "amazonec2-subnet-id=${runners_subnet_id}",
+      "amazonec2-private-address-only=${runners_use_private_address}",
+      "amazonec2-request-spot-instance=true", "amazonec2-spot-price=${runners_spot_price_bid}",
+      "amazonec2-security-group=${runners_security_group_name}",
+      "amazonec2-tags=environment,${environment}",
+      "amazonec2-monitoring=${runners_monitoring}",
+      "amazonec2-root-size=${runners_root_size}",
+      "amazonec2-iam-instance-profile=${runners_iam_instance_profile_name}"
+      ${docker_machine_options}
+    ]
     OffPeakTimezone = "${runners_off_peak_timezone}"
     OffPeakIdleCount = ${runners_off_peak_idle_count}
     OffPeakIdleTime = ${runners_off_peak_idle_time}

--- a/variables.tf
+++ b/variables.tf
@@ -255,3 +255,9 @@ variable "docker_machine_options" {
   type        = "list"
   default     = []
 }
+
+variable "instance_role_json" {
+  description = "Instance role json to override the default."
+  type        = "string"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,33 +29,6 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
-# list with amazon linux optimized images per region
-# HVM (SSD) EBS-Backed 64-bit
-# Amazon Linux AMI 2018.03 was released on 2018-06-28 https://aws.amazon.com/amazon-linux-ami/
-variable "amazon_optimized_amis" {
-  description = "AMI map per region-zone for the gitlab-runner instance AMI."
-  type        = "map"
-
-  default = {
-    us-east-1      = "ami-97785bed" # N. Virginia
-    us-east-2      = "ami-f63b1193" # Ohio
-    us-west-1      = "ami-824c4ee2" # N. California
-    us-west-2      = "ami-f2d3638a" # Oregon
-    eu-west-1      = "ami-d834aba1" # Ireland
-    eu-west-2      = "ami-403e2524" # London
-    eu-central-1   = "ami-5652ce39" # Frankfurt
-    eu-central-2   = "ami-8ee056f3" # Paris
-    ap-northeast-1 = "ami-ceafcba8" # Tokyo
-    ap-northeast-2 = "ami-863090e8" # Seoel
-    ap-southeast-1 = "ami-68097514" # Singapore
-    ap-southeast-2 = "ami-942dd1f6" # Sydney
-    ap-south-1     = "ami-531a4c3c" # Mumbai
-    ca-central-1   = "ami-a954d1cd" # Canada
-    sa-east-1      = "ami-84175ae8" # São Paulo
-    cn-north-1     = "ami-cb19c4a6" # Beijing
-  }
-}
-
 variable "ssh_public_key" {
   description = "Public SSH key used for the gitlab-runner ec2 instance."
   type        = "string"
@@ -260,4 +233,20 @@ variable "instance_role_json" {
   description = "Instance role json to override the default."
   type        = "string"
   default     = ""
+}
+
+variable "ami_filter" {
+  description = "AMI filter to select the AMI used to host the gitlab runner agent. By default the pattern `amzn-ami-hvm-2018.03*-x86_64-ebs` is used for the name. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks *not* working for this configuration."
+  type        = "list"
+
+  default = [{
+    name   = "name"
+    values = ["amzn-ami-hvm-2018.03*-x86_64-ebs"]
+  }]
+}
+
+variable "ami_owners" {
+  description = "A list of owners used to select the AMI for the instance."
+  type        = "list"
+  default     = ["amazon"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -249,3 +249,9 @@ variable "allow_iam_service_linked_role_creation" {
   description = "Attach policy to runner instance to create service linked roles."
   default     = true
 }
+
+variable "docker_machine_options" {
+  description = "Additional to set options for docker machien. Each element of the list should be key and value. E.g. '[\"--amazonec2-zone=a\"]'"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
- Changed: Replaced cache user by a instance profile to access the cache from the build
- Changed: Update gitlab toml cache section, removed deprecated usages of s3
- Changed: The variable `amazon_optimized_amis` is removed an replaced by a filter to select the AMI. To use the default of the latest AMI set the filter `ami_filter` to `amzn-ami-hvm-2018.03.0.20180622-x86_64-ebs`.
- Added: Option to set docker machine options via `docker_machine_optionns`.
- Added: Several output variables.