### PR TITLE
Fix comment for docker_machine_options (#35)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -234,7 +234,7 @@ variable "allow_iam_service_linked_role_creation" {
 }
 
 variable "docker_machine_options" {
-  description = "Additional to set options for docker machien. Each element of the list should be key and value. E.g. '[\"--amazonec2-zone=a\"]'"
+  description = "Additional to set options for docker machine. Each element of the list should be key and value. E.g. '[\"amazonec2-zone=a\"]'"
   type        = "list"
   default     = []
 }


### PR DESCRIPTION
* Fix example in comment for `docker_machine_options` - prepending the `--` is not necessary (in fact, breaks..)
* Fix typo too