### PR TITLE
Add AWS Zone support (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Bugfix: Correct example for docker_machine_options #36 (@declension)
+- Added: AWS Zone variable #35 (@declension)
 
 ## [2.1.0] - 2019-02-28
 - Bugfix: Shared cache is not working #33

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module "gitlab-runner" {
 | ami_filter | AMI filter to select the AMI used to host the gitlab runner agent. By default the pattern `amzn-ami-hvm-2018.03*-x86_64-ebs` is used for the name. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks *not* working for this configuration. | list | `<list>` | no |
 | ami_owners | A list of owners used to select the AMI for the instance. | list | `<list>` | no |
 | aws_region | AWS region. | string | - | yes |
+| aws_zone | AWS availability zone. | string | 'a' | no |
 | cache_bucket_prefix | Prefix for s3 cache bucket name. | string | `` | no |
 | cache_expiration_days | Number of days before cache objects expires. | string | `1` | no |
 | cache_shared | Enables cache sharing between runners, false by default. | string | `false` | no |

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -35,6 +35,7 @@ check_interval = 0
     MachineOptions = [
       "amazonec2-instance-type=${runners_instance_type}",
       "amazonec2-region=${aws_region}",
+      "amazonec2-zone=${aws_zone}",
       "amazonec2-vpc-id=${runners_vpc_id}",
       "amazonec2-subnet-id=${runners_subnet_id}",
       "amazonec2-private-address-only=${runners_use_private_address}",

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "aws_region" {
   type        = "string"
 }
 
+variable "aws_zone" {
+  description = "AWS availability zone (typically 'a', 'b', or 'c')."
+  type        = "string"
+  default     = "a"
+}
+
 variable "environment" {
   description = "A name that identifies the environment, will used as prefix and for tagging."
   type        = "string"


### PR DESCRIPTION
 * Add new variable for AWS Availability Zone, with default `a` (as implied it seems)
 * Specify zone explicitly in `MachineOptions`
 * Update documentation
 * Update changelog

This fixes #35