### PR TITLE
Added variable for shm_size in the runner config.toml.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,6 +149,7 @@ data "template_file" "runners" {
     runners_concurrent                = "${var.runners_concurrent}"
     runners_image                     = "${var.runners_image}"
     runners_privileged                = "${var.runners_privileged}"
+    runners_shm_size                  = "${var.runners_shm_size}"
     runners_idle_count                = "${var.runners_idle_count}"
     runners_idle_time                 = "${var.runners_idle_time}"
     runners_off_peak_timezone         = "${var.runners_off_peak_timezone}"

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -19,7 +19,7 @@ check_interval = 0
     privileged = ${runners_privileged}
     disable_cache = false
     volumes = ["/cache"]
-    shm_size = 0
+    shm_size = ${runners_shm_size}
   [runners.cache]
     Type = "s3"
     Shared = ${shared_cache}

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,11 @@ variable "runners_privileged" {
   default     = "true"
 }
 
+variable "runners_shm_size" {
+  description = "shm_size for the runners.  will be used in the runner config.toml"
+  default     = 0
+}
+
 variable "runners_monitoring" {
   description = "Enable detailed cloudwatch monitoring for spot instances."
   default     = false


### PR DESCRIPTION
After experiencing issues with our CI pipeline failing we realized it was related to not having shared memory for chrome, as related here: https://github.com/elgalu/docker-selenium/issues/20

I've added a variable to the recipe that defaults to 0 (to match the current value) so that this can be set in the runners config.toml.

Let me know if you have any suggestions on this PR, wasn't sure the best way to contribute to this project.