### PR TITLE
Add option to disable SSH to the runner instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "runner" {
   tags = "${local.tags}"
 }
 
-resource "aws_security_group_rule" "ssh_runner" {
+resource "aws_security_group_rule" "ssh" {
   count = "${var.enable_gitlab_runner_ssh_access}"
 
   type        = "ingress"
@@ -22,7 +22,7 @@ resource "aws_security_group_rule" "ssh_runner" {
   security_group_id = "${aws_security_group.runner.id}"
 }
 
-resource "aws_security_group_rule" "out_all_runner" {
+resource "aws_security_group_rule" "out_all" {
   type        = "egress"
   from_port   = 0
   to_port     = 65535
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "docker" {
   security_group_id = "${aws_security_group.docker_machine.id}"
 }
 
-resource "aws_security_group_rule" "ssh_docker_machine" {
+resource "aws_security_group_rule" "ssh" {
   type        = "ingress"
   from_port   = 22
   to_port     = 22
@@ -59,7 +59,7 @@ resource "aws_security_group_rule" "ssh_docker_machine" {
   security_group_id = "${aws_security_group.docker_machine.id}"
 }
 
-resource "aws_security_group_rule" "out_all_docker_machine" {
+resource "aws_security_group_rule" "out_all" {
   type        = "egress"
   from_port   = 0
   to_port     = 65535

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "runner" {
 }
 
 resource "aws_security_group_rule" "ssh_runner" {
-  count = "${var.gitlab_runner_ssh_access}"
+  count = "${var.enable_gitlab_runner_ssh_access}"
 
   type        = "ingress"
   from_port   = 22

--- a/variables.tf
+++ b/variables.tf
@@ -236,6 +236,17 @@ variable "gitlab_runner_version" {
   default     = "11.9.1"
 }
 
+variable "enable_gitlab_runner_ssh_access" {
+  description = "Enables SSH Access to the gitlab runner instance."
+  default     = false
+}
+
+variable "gitlab_runner_ssh_cidr_blocks" {
+  description = "List of CIDR blocks to allow SSH Access from to the gitlab runner instance."
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "enable_cloudwatch_logging" {
   description = "Boolean used to enable or disable the CloudWatch logging."
   default     = true


### PR DESCRIPTION
This PR addresses issue #47 and also adds a way of limiting SSH ingress to a list of CIDR blocks.