### PR TITLE
Fix #64 - remove unused security group add SSH rule to runner group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,14 +32,6 @@ resource "aws_security_group" "runner" {
   tags = "${merge(local.tags, map("Name", format("%s", local.name_sg)))}"
 }
 
-resource "aws_security_group" "runner_ssh" {
-  count       = "${var.enable_gitlab_runner_ssh_access ? 1 : 0}"
-  name_prefix = "${var.environment}-security-group"
-  vpc_id      = "${var.vpc_id}"
-
-  tags = "${local.tags}"
-}
-
 resource "aws_security_group_rule" "runner_ssh" {
   count = "${var.enable_gitlab_runner_ssh_access ? 1 : 0}"
 
@@ -49,7 +41,7 @@ resource "aws_security_group_rule" "runner_ssh" {
   protocol    = "tcp"
   cidr_blocks = ["${var.gitlab_runner_ssh_cidr_blocks}"]
 
-  security_group_id = "${aws_security_group.runner_ssh.id}"
+  security_group_id = "${aws_security_group.runner.id}"
 }
 
 resource "aws_security_group" "docker_machine" {


### PR DESCRIPTION
## Description
Fix for #64 removed unused security group

## Migrations required
NO

## Verification
runners-public

