### PR TITLE
Fix #68 - add count to prevent resource creation failing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -192,8 +192,8 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   launch_configuration      = "${aws_launch_configuration.gitlab_runner_instance.name}"
 
   tags = [
-    "${concat( 
-        data.null_data_source.tags.*.outputs, 
+    "${concat(
+        data.null_data_source.tags.*.outputs,
         list(map("key", "Name", "value", local.name_runner_instance, "propagate_at_launch", true)))}",
   ]
 }
@@ -346,6 +346,8 @@ resource "aws_iam_policy" "ssm" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
+  count = "${var.enable_manage_gitlab_token ? 1 : 0}"
+
   role       = "${aws_iam_role.instance.name}"
   policy_arn = "${aws_iam_policy.ssm.arn}"
 }


### PR DESCRIPTION
## Description
Before this PR, setting `enable_manage_gitlab_token` to `false` made the plan fails (see #68)

## Migrations required
NO

## Verification
runner-default


