### PR TITLE
Fix #70 - update policy to allow runners to start when not using spot instances

### DIFF
--- a/policies/instance-docker-machine-policy.json
+++ b/policies/instance-docker-machine-policy.json
@@ -1,26 +1,27 @@
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:DescribeKeyPairs",
-        "ec2:TerminateInstances",
-        "ec2:StopInstances",
-        "ec2:StartInstances",
-        "ec2:RebootInstances",
-        "ec2:CreateKeyPair",
-        "ec2:DeleteKeyPair",
-        "ec2:ImportKeyPair",
-        "ec2:Describe*",
-        "ec2:CreateTags",
-        "ec2:RequestSpotInstances",
-        "ec2:CancelSpotInstanceRequests",
-        "ec2:DescribeSubnets",
-        "ec2:AssociateIamInstanceProfile",
-        "iam:PassRole"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ec2:DescribeKeyPairs",
+          "ec2:TerminateInstances",
+          "ec2:StopInstances",
+          "ec2:StartInstances",
+          "ec2:RunInstances",
+          "ec2:RebootInstances",
+          "ec2:CreateKeyPair",
+          "ec2:DeleteKeyPair",
+          "ec2:ImportKeyPair",
+          "ec2:Describe*",
+          "ec2:CreateTags",
+          "ec2:RequestSpotInstances",
+          "ec2:CancelSpotInstanceRequests",
+          "ec2:DescribeSubnets",
+          "ec2:AssociateIamInstanceProfile",
+          "iam:PassRole"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }


### PR DESCRIPTION

## Description
see #70 

## Migrations required
NO

## Verification
runner-default

## Documentation
no change