### PR TITLE
Fix runner is not reachable when runners_use_private_address = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
   spot_price           = "${var.runner_instance_spot_price}"
   iam_instance_profile = "${aws_iam_instance_profile.instance.name}"
 
-  associate_public_ip_address = false
+  associate_public_ip_address = "${!var.runners_use_private_address}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description
This fixes the issue #75 the runner is not reachable when the following conditions satisfy:

- `runners_use_private_address = false`
- the subnet is public (i.e. the default route is to an Internet Gateway)
- `map_public_ip_on_launch` of the subnet is default

## Migrations required
No.

## Verification
Tested with the example project: https://github.com/int128/aws-gitlab-runner-starter.

## Documentation
No change.
