### PR TITLE
Fix: docker-machine cert generation

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -21,6 +21,10 @@ curl  --fail --retry 6 -L https://github.com/docker/machine/releases/download/v$
   cp /tmp/docker-machine /usr/local/bin/docker-machine && \
   ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine
 
+# Create a dummy machine so that the cert is generated properly
+# See: https://gitlab.com/gitlab-org/gitlab-runner/issues/3676
+docker-machine create --driver none --url localhost dummy-machine
+
 
 token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
 if [[ `echo ${runners_token}` == "__REPLACED_BY_USER_DATA__" && `echo $token` == "null" ]]


### PR DESCRIPTION
## Description
If the gitlab-runner tries to spin up multiple machines when it's first
initialized it runs docker-machine commands in parallel which can
cause it to generate competing certificates. To avoid that have
docker-machine create a dummy-machine first.

https://gitlab.com/gitlab-org/gitlab-runner/issues/3676

## Migrations required
NO

## Verification
default example

## Documentation
Please ensure you pdate the README in `_docs/README.md`. The README.md in the root can be update by running the script `ci/bin/autodocs.sh`
