### PR TITLE
Fix misleading variable description

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ terraform destroy
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | string | `"false"` | no |
-| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the Gitlab token will be managed via terraform state. If `false` the token will still be stored in SSM however, it will not be managed via terraform. | string | `"true"` | no |
+| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM however, it will not be managed via terraform. If `false` the Gitlab token will be managed via terraform state. | string | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ terraform destroy
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | string | `"false"` | no |
-| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM however, it will not be managed via terraform. If `false` the Gitlab token will be managed via terraform state. | string | `"true"` | no |
+| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -330,7 +330,7 @@ variable "secure_parameter_store_runner_token_key" {
 }
 
 variable "enable_manage_gitlab_token" {
-  description = "Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM however, it will not be managed via terraform. If `false` the Gitlab token will be managed via terraform state."
+  description = "Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`."
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -330,7 +330,7 @@ variable "secure_parameter_store_runner_token_key" {
 }
 
 variable "enable_manage_gitlab_token" {
-  description = "Boolean to enable the management of the GitLab token in SSM. If `true` the Gitlab token will be managed via terraform state. If `false` the token will still be stored in SSM however, it will not be managed via terraform."
+  description = "Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM however, it will not be managed via terraform. If `false` the Gitlab token will be managed via terraform state."
   default     = true
 }
 


### PR DESCRIPTION
## Description
changes the description for the variable `enable_manage_gitlab_token`, since the second part of the description is misleading

## Migrations required
NO

## Verification
tried to build the infrastructure with this module and believed the wrong part of the description. So, I had chosen the wrong value for this variable.

## Documentation
README was updated
