### PR TITLE
use latest ubuntu 18.04 for gitlab runner instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,7 @@ data "template_file" "runners" {
     runners_subnet_id                 = "${var.subnet_id_runners}"
     runners_aws_zone                  = "${var.aws_zone}"
     runners_instance_type             = "${var.docker_machine_instance_type}"
+    runners_ami                       = "${data.aws_ami.docker-machine.id}"
     runners_spot_price_bid            = "${var.docker_machine_spot_price_bid}"
     runners_security_group_name       = "${aws_security_group.docker_machine.name}"
     runners_monitoring                = "${var.runners_monitoring}"
@@ -197,6 +198,14 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
         data.null_data_source.tags.*.outputs,
         list(map("key", "Name", "value", local.name_runner_instance, "propagate_at_launch", true)))}",
   ]
+}
+
+data "aws_ami" "docker-machine" {
+  most_recent = true
+
+  filter = "${var.runner_ami_filter}"
+
+  owners = ["${var.runner_ami_owners}"]
 }
 
 data "aws_ami" "runner" {

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -47,7 +47,8 @@ check_interval = 0
       "amazonec2-tags=${runners_tags}",
       "amazonec2-monitoring=${runners_monitoring}",
       "amazonec2-iam-instance-profile=${runners_instance_profile}",
-      "amazonec2-root-size=${runners_root_size}"
+      "amazonec2-root-size=${runners_root_size}",
+      "amazonec2-ami=${runners_ami}"
       ${docker_machine_options}
     ]
     OffPeakTimezone = "${runners_off_peak_timezone}"

--- a/variables.tf
+++ b/variables.tf
@@ -315,6 +315,24 @@ variable "ami_owners" {
   default     = ["amazon"]
 }
 
+variable "runner_ami_filter" {
+  description = "List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI."
+  type        = "list"
+
+  default = [{
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }]
+}
+
+variable "runner_ami_owners" {
+  description = "The list of owners used to select the AMI of Gitlab runner docker-machine instances."
+  type        = "list"
+
+  # Canonical
+  default = ["099720109477"]
+}
+
 variable "gitlab_runner_registration_config" {
   description = "Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo."
   type        = "map"


### PR DESCRIPTION
## Description
The default image used for the docker-machine EC2 instances is rather old. In this PR this is changed to use the latest AMI of Ubuntu 18.04 available on AWS EC2.

## Migrations required
NO

## Verification
Works without problems in our installation for a few weeks
