### PR TITLE
Adding docker pull policy Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Terraform module for GitLab auto scaling runners on AWS spot instances
 
-> *WIP*: Work in progress, conversion to Terraform 0.12 #73. Feel free to checkout branch [Terraform 0.12](https://github.com/npalm/terraform-aws-gitlab-runner/tree/feature/terraform-0.12).
+> *WIP*: Work in progress, conversion to Terraform 0.12 \#73. Feel free to checkout branch [Terraform 0.12](https://github.com/npalm/terraform-aws-gitlab-runner/tree/feature/terraform-0.12).
 
 > *NEW*: The runner will register itself automatically to GitLab. No need to register the runner first, see also the [examples](./examples)
 
@@ -231,6 +231,7 @@ terraform destroy
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | string | `"true"` | no |
+| runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -3,6 +3,8 @@
 
 # Terraform module for GitLab auto scaling runners on AWS spot instances
 
+> *WIP*: Work in progress, conversion to Terraform 0.12 #73. Feel free to checkout branch [Terraform 0.12](https://github.com/npalm/terraform-aws-gitlab-runner/tree/feature/terraform-0.12).
+
 > *NEW*: The runner will register itself automatically to GitLab. No need to register the runner first, see also the [examples](./examples)
 
 This repo contains a Terraform module and examples to run a [GitLab CI multi runner](https://docs.gitlab.com/runner/) on AWS Spot instances. See the blog post at [040code](https://040code.github.io/2017/12/09/runners-on-the-spot/) for a detailed description of the setup.

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -19,7 +19,7 @@
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | string | `"false"` | no |
-| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the Gitlab token will be managed via terraform state. If `false` the token will still be stored in SSM however, it will not be managed via terraform. | string | `"true"` | no |
+| enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -50,6 +50,7 @@
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | string | `"true"` | no |
+| runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ data "template_file" "runners" {
     runners_image                     = "${var.runners_image}"
     runners_privileged                = "${var.runners_privileged}"
     runners_shm_size                  = "${var.runners_shm_size}"
+    runners_pull_policy               = "${var.runners_pull_policy}"
     runners_idle_count                = "${var.runners_idle_count}"
     runners_idle_time                 = "${var.runners_idle_time}"
     runners_off_peak_timezone         = "${var.runners_off_peak_timezone}"

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -20,6 +20,7 @@ check_interval = 0
     disable_cache = false
     volumes = ["/cache"]
     shm_size = ${runners_shm_size}
+    pull_policy = "${runners_pull_policy}"
   [runners.cache]
     Type = "s3"
     Shared = ${shared_cache}

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,12 @@ variable "runners_shm_size" {
   default     = 0
 }
 
+variable "runners_pull_policy" {
+  description = "pull_policy for the runners.  will be used in the runner config.toml"
+  type        = "string"
+  default     = "always"
+}
+
 variable "runners_monitoring" {
   description = "Enable detailed cloudwatch monitoring for spot instances."
   default     = false


### PR DESCRIPTION
## Description
Adding additional parameter to specify the Docker Pull Policy for the Gitlab Runner

## Migrations required
NO

## Verification
has been in production in our setup for a few weeks with parameter if-not-present. default value is the default from Gitlab

## Documentation
Documentation was updated to include the additional parameter. Also it was updated from upstream and fixed minor autodoc issue.
