### PR TITLE
ci script update

### DIFF
--- a/ci/bin/autodocs.sh
+++ b/ci/bin/autodocs.sh
@@ -2,8 +2,8 @@
 
 # script to auto-generate terraform documentation
 
-pandoc -v &> /dev/null || echo "ERROR: Pandoc not installed"
-terraform-docs --version &> /dev/null || echo "ERROR: terraform-docs not installed"
+pandoc -v &> /dev/null || { echo >&2 "ERROR: Pandoc not installed" ; exit 1 ; }
+terraform-docs --version &> /dev/null || { echo >&2 "ERROR: terraform-docs not installed" ; exit 1 ; }
 
 IFS=$'\n'
 # create an array of all unique directories containing .tf files 

--- a/ci/bin/verify-examples.sh
+++ b/ci/bin/verify-examples.sh
@@ -4,7 +4,8 @@ DIR=${1:-examples}
 source $(dirname $0)/terraform.sh
 
 EXAMPLES="$(find ${DIR} -maxdepth 1 -mindepth 1 -type d 2> /dev/null )"
-if [[ -z $EXAMPLES || "$($(echo $EXAMPLES) | wc -l)" -gt 0  ]] ; then
+echo $EXAMPLES
+if [[ -z $EXAMPLES || $( echo $EXAMPLES | wc -l )  -eq 0  ]] ; then
   echo "No example(s) directories found."
   exit 1
 fi


### PR DESCRIPTION
## Description
fix small issues with the ci scripts:
- autodocs.sh did not exit if pandoc or terraform-docs were not installed
- ci/bin/verify-examples.sh had incorrect check for examples and printed some useless  errors

## Migrations required
NO

## Verification
N/A

## Documentation
N/A
