### PR TITLE
fix: availability zone in AWS region

### DIFF
--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -5,7 +5,7 @@ module "vpc" {
   name = "vpc-${var.environment}"
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a"]
+  azs             = ["${var.aws_region}a"]
   private_subnets = ["10.0.1.0/24"]
   public_subnets  = ["10.0.101.0/24"]
 

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.66.0"
@@ -5,7 +9,7 @@ module "vpc" {
   name = "vpc-${var.environment}"
   cidr = "10.0.0.0/16"
 
-  azs             = ["${var.aws_region}a"]
+  azs             = ["${data.aws_availability_zones.available.names[0]}"]
   private_subnets = ["10.0.1.0/24"]
   public_subnets  = ["10.0.101.0/24"]
 

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.66.0"
@@ -5,7 +9,7 @@ module "vpc" {
   name = "vpc-${var.environment}"
   cidr = "10.1.0.0/16"
 
-  azs                = ["eu-west-1a"]
+  azs                = ["${data.aws_availability_zones.available.names[0]}"]
   public_subnets     = ["10.1.101.0/24"]
   enable_s3_endpoint = true
 

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.60.0"
@@ -5,7 +9,7 @@ module "vpc" {
   name = "vpc-${var.environment}"
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a"]
+  azs             = ["${data.aws_availability_zones.available.names[0]}"]
   private_subnets = ["10.0.1.0/24"]
   public_subnets  = ["10.0.101.0/24"]
 

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.66.0"
@@ -5,7 +9,7 @@ module "vpc" {
   name = "vpc-${var.environment}"
   cidr = "10.1.0.0/16"
 
-  azs            = ["eu-west-1b"]
+  azs            = ["${data.aws_availability_zones.available.names[0]}"]
   public_subnets = ["10.1.101.0/24"]
 
   map_public_ip_on_launch = "false"


### PR DESCRIPTION
## Description
Use valid availability zones when using a region other than `eu-west-1`.

## Migrations required
NO - If yes please describe the mirgration.

## Verification
Please mentioned the examples you have verified.

## Documentation
Please ensure you pdate the README in `_docs/README.md`. The README.md in the root can be update by running the script `ci/bin/autodocs.sh`
