### PR TITLE
fix: use a variable to determine timezone

### DIFF
--- a/examples/runner-default/README.md
+++ b/examples/runner-default/README.md
@@ -17,3 +17,4 @@ The terraform version is managed using [tfenv](https://github.com/Zordrak/tfenv)
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | registration\_token |  | string | n/a | yes |
 | runner\_name | Name of the runner, will be used in the runner config.toml | string | `"default-auto"` | no |
+| timezone | Name of the timezone that the runner will be used in. | string | `"Europe/Amsterdam"` | no |

--- a/examples/runner-default/_docs/TF_MODULE.md
+++ b/examples/runner-default/_docs/TF_MODULE.md
@@ -9,4 +9,5 @@
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | registration\_token |  | string | n/a | yes |
 | runner\_name | Name of the runner, will be used in the runner config.toml | string | `"default-auto"` | no |
+| timezone | Name of the timezone that the runner will be used in. | string | `"Europe/Amsterdam"` | no |
 

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -44,7 +44,7 @@ module "runner" {
     maximum_timeout    = "3600"
   }
 
-  runners_off_peak_timezone   = "Europe/Amsterdam"
+  runners_off_peak_timezone   = "${var.timezone}"
   runners_off_peak_idle_count = 0
   runners_off_peak_idle_time  = 60
 

--- a/examples/runner-default/variables.tf
+++ b/examples/runner-default/variables.tf
@@ -31,3 +31,9 @@ variable "gitlab_url" {
 }
 
 variable "registration_token" {}
+
+variable "timezone" {
+  description = "Name of the timezone that the runner will be used in."
+  type        = "string"
+  default     = "Europe/Amsterdam"
+}

--- a/examples/runner-pre-registered/README.md
+++ b/examples/runner-pre-registered/README.md
@@ -17,3 +17,4 @@ The terraform version is managed using [tfenv](https://github.com/Zordrak/tfenv)
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | runner\_name | Name of the runner, will be used in the runner config.toml | string | n/a | yes |
 | runner\_token | Token for the runner, will be used in the runner config.toml | string | n/a | yes |
+| timezone | Name of the timezone that the runner will be used in. | string | `"Europe/Amsterdam"` | no |

--- a/examples/runner-pre-registered/_docs/TF_MODULE.md
+++ b/examples/runner-pre-registered/_docs/TF_MODULE.md
@@ -9,4 +9,5 @@
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | runner\_name | Name of the runner, will be used in the runner config.toml | string | n/a | yes |
 | runner\_token | Token for the runner, will be used in the runner config.toml | string | n/a | yes |
+| timezone | Name of the timezone that the runner will be used in. | string | `"Europe/Amsterdam"` | no |
 

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -35,7 +35,7 @@ module "runner" {
   runners_gitlab_url = "${var.gitlab_url}"
   runners_token      = "${var.runner_token}"
 
-  runners_off_peak_timezone   = "Europe/Amsterdam"
+  runners_off_peak_timezone   = "${var.timezone}"
   runners_off_peak_idle_count = 0
   runners_off_peak_idle_time  = 60
 

--- a/examples/runner-pre-registered/variables.tf
+++ b/examples/runner-pre-registered/variables.tf
@@ -32,3 +32,9 @@ variable "runner_token" {
   description = "Token for the runner, will be used in the runner config.toml"
   type        = "string"
 }
+
+variable "timezone" {
+  description = "Name of the timezone that the runner will be used in."
+  type        = "string"
+  default     = "Europe/Amsterdam"
+}


### PR DESCRIPTION
## Description
I want to be able to specify the timezone used for idle time in a variable.

## Migrations required
NO - If yes please describe the mirgration.

## Verification
Please mentioned the examples you have verified.

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
