### PR TITLE
Mount docker socket

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,10 @@
 A few sentences describing the overall goals of the pull request's commits.
 
 ## Migrations required
-YES | NO - If yes please describe the mirgration.
+YES | NO - If yes please describe the migration.
 
 ## Verification
-Please mentioned the examples you have verified.
+Please mention the examples you have verified.
 
 ## Documentation
-Please ensure you pdate the README in `_docs/README.md`. The README.md in the root can be update by running the script `ci/bin/autodocs.sh`
+Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ terraform destroy
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | string | `"10"` | no |
-| runners\_mount\_docker_socket | Runners will mount volume with Docker socket, will be used in the runner config.toml | string | `""` | no |
 | runners\_docker\_socket | Location of Docker socket on host if socket mount if enabled, will be used in the runner config.toml | string | `"/var/run/docker.sock"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
 | runners\_executor | The executor to use. Currently supports `docker+machine` or `docker`. | string | `"docker+machine"` | no |
@@ -225,6 +224,7 @@ terraform destroy
 | runners\_image | Image to run builds, will be used in the runner config.toml | string | `"docker:18.03.1-ce"` | no |
 | runners\_limit | Limit for the runners, will be used in the runner config.toml. | string | `"0"` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | string | `"false"` | no |
+| runners\_mount\_docker_socket | Runners will mount volume with Docker socket, will be used in the runner config.toml | string | `""` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | string | n/a | yes |
 | runners\_off\_peak\_idle\_count | Off peak idle count of the runners, will be used in the runner config.toml. | string | `"0"` | no |
 | runners\_off\_peak\_idle\_time | Off peak idle time of the runners, will be used in the runner config.toml. | string | `"0"` | no |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ terraform destroy
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | string | `"10"` | no |
+| runners\_mount\_docker_socket | Runners will mount volume with Docker socket, will be used in the runner config.toml | string | `""` | no |
+| runners\_docker\_socket | Location of Docker socket on host if socket mount if enabled, will be used in the runner config.toml | string | `"/var/run/docker.sock"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
 | runners\_executor | The executor to use. Currently supports `docker+machine` or `docker`. | string | `"docker+machine"` | no |
 | runners\_gitlab\_url | URL of the GitLab instance to connect to. | string | n/a | yes |

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -39,6 +39,9 @@ module "runner" {
   runners_gitlab_url       = var.gitlab_url
   runners_environment_vars = ["KEY=Value", "FOO=bar"]
 
+  runners_privileged = "false"
+  runners_mount_docker_socket = "true"
+
   gitlab_runner_registration_config = {
     registration_token = var.registration_token
     tag_list           = "docker_spot_runner"

--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,8 @@ data "template_file" "runners" {
     runners_security_group_name = aws_security_group.docker_machine.name
     runners_monitoring          = var.runners_monitoring
     runners_instance_profile    = aws_iam_instance_profile.docker_machine.name
+    runners_mount_docker_socket = var.runners_mount_docker_socket
+    runners_docker_socket       = var.runners_docker_socket
     docker_machine_options      = length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string
     runners_name                = var.runners_name
     runners_tags = var.overrides["name_docker_machine_runners"] == "" ? format(

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,4 +17,3 @@ output "runner_role" {
   description = "ARN of the rule used for the docker machine runners."
   value       = aws_iam_role.docker_machine.arn
 }
-

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -25,6 +25,10 @@ curl  --fail --retry 6 -L https://github.com/docker/machine/releases/download/v$
 # See: https://gitlab.com/gitlab-org/gitlab-runner/issues/3676
 docker-machine create --driver none --url localhost dummy-machine
 
+# Install jq if not exists
+if ! [ -x "$(command -v jq)" ]; then
+  yum install jq -y
+fi
 
 token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
 if [[ `echo ${runners_token}` == "__REPLACED_BY_USER_DATA__" && `echo $token` == "null" ]]

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -18,7 +18,7 @@ check_interval = 0
     image = "${runners_image}"
     privileged = ${runners_privileged}
     disable_cache = false
-    volumes = ["/cache"]
+    volumes = ["/cache"%{ if runners_mount_docker_socket == "true" }, "${runners_docker_socket}"%{ endif ~}]
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
   [runners.cache]

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -18,7 +18,7 @@ check_interval = 0
     image = "${runners_image}"
     privileged = ${runners_privileged}
     disable_cache = false
-    volumes = ["/cache"%{ if runners_mount_docker_socket == "true" }, "${runners_docker_socket}"%{ endif ~}]
+    volumes = ["/cache"%{ if runners_mount_docker_socket == "true" },"${runners_docker_socket}"%{ endif ~}]
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
   [runners.cache]

--- a/variables.tf
+++ b/variables.tf
@@ -124,7 +124,7 @@ variable "runners_mount_docker_socket" {
 variable "runners_docker_socket" {
   description = "Location of Docker socket on host if socket mount if enabled, will be used in the runner config.toml"
   type        = "string"
-  default     = "/var/run/docker.sock"
+  default     = "/var/run/docker.sock:/var/run/docker.sock"
 }
 
 variable "runners_shm_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,18 @@ variable "runners_privileged" {
   default     = "true"
 }
 
+variable "runners_mount_docker_socket" {
+  description = "Runners will mount volume with Docker socket, will be used in the runner config.toml"
+  type        = "string"
+  default     = "false"
+}
+
+variable "runners_docker_socket" {
+  description = "Location of Docker socket on host if socket mount if enabled, will be used in the runner config.toml"
+  type        = "string"
+  default     = "/var/run/docker.sock"
+}
+
 variable "runners_shm_size" {
   description = "shm_size for the runners, will be used in the runner config.toml"
   default     = 0


### PR DESCRIPTION
## Description
This will add an optional Docker socket mount as an alternative (opinionated to be better) option to privileged mode

## Migrations required
NO

## Verification
It works with default example in our setup

## Documentation
Updated
