### PR TITLE
Add variable docker_machine_role_json allowing role policy customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ terraform destroy
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | string | `"true"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
+| docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
@@ -222,8 +223,7 @@ terraform destroy
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"11.11.2"` | no |
-| instance\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
-| instance\_role\_runner\_json | Instance role json for the docker machine runners to override the default. | string | `""` | no |
+| instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
 | name\_runners\_docker\_machine |  | string | `""` | no |
 | overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map | `<map>` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -15,6 +15,7 @@
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | string | `"true"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
+| docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
@@ -25,8 +26,7 @@
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"11.11.2"` | no |
-| instance\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
-| instance\_role\_runner\_json | Instance role json for the docker machine runners to override the default. | string | `""` | no |
+| instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
 | name\_runners\_docker\_machine |  | string | `""` | no |
 | overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -303,7 +303,7 @@ resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
 ### docker machine instance policy
 ################################################################################
 data "template_file" "dockermachine_role_trust_policy" {
-  template = "${file("${path.module}/policies/instance-role-trust-policy.json")}"
+  template = "${length(var.docker_machine_role_json) > 0 ? var.docker_machine_role_json : file("${path.module}/policies/instance-role-trust-policy.json")}"
 }
 
 resource "aws_iam_role" "docker_machine" {

--- a/variables.tf
+++ b/variables.tf
@@ -288,13 +288,13 @@ variable "docker_machine_options" {
 }
 
 variable "instance_role_json" {
-  description = "Docker machine runner instance override policy, expected to be in JSON format."
+  description = "Default runner instance override policy, expected to be in JSON format."
   type        = "string"
   default     = ""
 }
 
-variable "instance_role_runner_json" {
-  description = "Instance role json for the docker machine runners to override the default."
+variable "docker_machine_role_json" {
+  description = "Docker machine runner instance override policy, expected to be in JSON format."
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
## Description

I updated the description of the `instance_role_json` variable as the it was not accurate, the json template passed is applied on the `runners-default-instance-role` and not the `runners-default-docker-machine-role`.

I also removed the unused `instance_role_runner_json` variable as it was only define as variable and replaced it with a new `docker_machine_role_json` variable that allows customization of the policy of the `runners-default-docker-machine-role` role.

The behavior is the same than before if a user does not use the new `docker_machine_role_json` variable.

## Migrations required
No.

## Verification
Validated on a private gitlab instance but please do validate as well.

## Documentation
Documentation has been updated using the autodocs.sh script.
