### PR TITLE
Add variable docker_machine_ssh_cidr_blocks allowing ssh ingress restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ terraform destroy
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
+| docker\_machine\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the docker machine runner instance. | list | `<list>` | no |
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
@@ -220,7 +221,7 @@ terraform destroy
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
-| gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |
+| gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the gitlab runner instance. | list | `<list>` | no |
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"11.11.2"` | no |
 | instance\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_role\_runner\_json | Instance role json for the docker machine runners to override the default. | string | `""` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -16,6 +16,7 @@
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
+| docker\_machine\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the docker machine runner instance. | list | `<list>` | no |
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.1"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
@@ -23,7 +24,7 @@
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map | `<map>` | no |
-| gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access from to the gitlab runner instance. | list | `<list>` | no |
+| gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the gitlab runner instance. | list | `<list>` | no |
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"11.11.2"` | no |
 | instance\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_role\_runner\_json | Instance role json for the docker machine runners to override the default. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "ssh" {
   from_port   = 22
   to_port     = 22
   protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = ["${var.docker_machine_ssh_cidr_blocks}"]
 
   security_group_id = "${aws_security_group.docker_machine.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -260,7 +260,13 @@ variable "enable_gitlab_runner_ssh_access" {
 }
 
 variable "gitlab_runner_ssh_cidr_blocks" {
-  description = "List of CIDR blocks to allow SSH Access from to the gitlab runner instance."
+  description = "List of CIDR blocks to allow SSH Access to the gitlab runner instance."
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "docker_machine_ssh_cidr_blocks" {
+  description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance."
   type        = "list"
   default     = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
## Description
My company uses CloudSploit (https://cloudsploit.com/) to monitor our AWS account, the current configuration causes alerts because of the ingress configuration of the docker machine instance. As such, I added the `docker_machine_ssh_cidr_blocks` to allow the configuration of this value like the `gitlab_runner_ssh_cidr_blocks` variable does.

## Migrations required
No

## Verification
Deployed on a private instance.

## Documentation
Documentation has been updated.
