### PR TITLE
Add runners_volumes variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ terraform destroy
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
+| runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -60,6 +60,7 @@
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
+| runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ data "template_file" "runners" {
     runners_concurrent                = "${var.runners_concurrent}"
     runners_image                     = "${var.runners_image}"
     runners_privileged                = "${var.runners_privileged}"
+    runners_volumes                   = "${length(var.runners_volumes) == 0 ? "[]" : format("[\"%s\"]", join("\", \"", var.runners_volumes))}"
     runners_shm_size                  = "${var.runners_shm_size}"
     runners_pull_policy               = "${var.runners_pull_policy}"
     runners_idle_count                = "${var.runners_idle_count}"

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -18,7 +18,7 @@ check_interval = 0
     image = "${runners_image}"
     privileged = ${runners_privileged}
     disable_cache = false
-    volumes = ["/cache"]
+    volumes = ${runners_volumes}
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
   [runners.cache]

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,12 @@ variable "runners_privileged" {
   default     = "true"
 }
 
+variable "runners_volumes" {
+  description = "Specify additional volumes that should be mounted (same syntax as Docker’s -v flag)"
+  type        = "list"
+  default     = ["/cache"]
+}
+
 variable "runners_shm_size" {
   description = "shm_size for the runners.  will be used in the runner config.toml"
   default     = 0


### PR DESCRIPTION
## Description
One of the needs of my team is to build docker image from Gitlab, to do that we currently use this option https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-socket-binding and therefore need to be able to customize the volumes set in the `config.toml` template.

This pull request adds support for that and default to `["/cache"]` if not provided to support the existing behavior.

Usage in my case:

```
runners_volumes = ["/cache", "/var/run/docker.sock:/var/run/docker.sock"]
```

## Migrations required
No

## Verification
Deployed and validated on a private gitlab instance.

## Documentation
Updated.