### PR TITLE
Namespace tags

### DIFF
--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -48,6 +48,11 @@ module "runner" {
     maximum_timeout    = "3600"
   }
 
+  tags = {
+    "tf-aws-gitlab-runner:example" = "runner-default"
+    "tf-aws-gitlab-runner:instancelifecycle" = "spot:yes"
+  }
+
   runners_off_peak_timezone   = var.timezone
   runners_off_peak_idle_count = 0
   runners_off_peak_idle_time  = 60

--- a/tags.tf
+++ b/tags.tf
@@ -9,11 +9,9 @@ locals {
     var.tags,
   )
 
-  tags_string = replace(
-    replace(jsonencode(local.tags), "/[\\{\\}\"\\s]/", ""),
-    ":",
-    ",",
-  )
+  tags_string = join(",",flatten([
+    for key in keys(local.tags) : [ key, lookup(local.tags,key) ]
+  ]))
 }
 
 data "null_data_source" "tags" {

--- a/tags.tf
+++ b/tags.tf
@@ -9,8 +9,8 @@ locals {
     var.tags,
   )
 
-  tags_string = join(",",flatten([
-    for key in keys(local.tags) : [ key, lookup(local.tags,key) ]
+  tags_string = join(",", flatten([
+    for key in keys(local.tags) : [key, lookup(local.tags, key)]
   ]))
 }
 


### PR DESCRIPTION
## Description
Fix the generation of etc2 instance tags in runner userdata when the name or value of a tag contains a ":".  Fix for #111 .

## Migrations required
NO

## Verification
default-runner-example now includes these tags, ran that example and verified the userdata sent to those boxes has the tags split correctly.

## Documentation
Should not be required, no interface change.