### PR TITLE
Cache bucket name optional account

### DIFF
--- a/cache/main.tf
+++ b/cache/main.tf
@@ -13,7 +13,7 @@ locals {
     var.tags,
   )
 
-  cache_bucket_name = cache_bucket_name_include_account_id == "true" ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
+  cache_bucket_name = var.cache_bucket_name_include_account_id == "true" ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
 }
 
 resource "aws_s3_bucket" "build_cache" {

--- a/cache/main.tf
+++ b/cache/main.tf
@@ -12,12 +12,14 @@ locals {
     },
     var.tags,
   )
+
+  cache_bucket_name = cache_bucket_name_include_account_id == "true" ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
 }
 
 resource "aws_s3_bucket" "build_cache" {
   count = var.create_cache_bucket ? 1 : 0
 
-  bucket = "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache"
+  bucket = local.cache_bucket_name
   acl    = "private"
 
   tags = local.tags

--- a/cache/variables.tf
+++ b/cache/variables.tf
@@ -11,8 +11,8 @@ variable "cache_bucket_prefix" {
 
 variable "cache_bucket_name_include_account_id" {
   description = "Boolean to add current account ID to cache bucket name."
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "cache_bucket_versioning" {

--- a/cache/variables.tf
+++ b/cache/variables.tf
@@ -9,6 +9,12 @@ variable "cache_bucket_prefix" {
   default     = ""
 }
 
+variable "cache_bucket_name_include_account_id" {
+  description = "Boolean to add current account ID to cache bucket name."
+  type        = string
+  default     = "true"
+}
+
 variable "cache_bucket_versioning" {
   description = "Boolean used to enable versioning on the cache bucket, false by default."
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -269,6 +269,7 @@ module "cache" {
 
   create_cache_bucket     = var.cache_bucket["create"]
   cache_bucket_prefix     = var.cache_bucket_prefix
+  cache_bucket_name_include_account_id = var.cache_bucket_name_include_account_id
   cache_bucket_versioning = var.cache_bucket_versioning
   cache_expiration_days   = var.cache_expiration_days
 }

--- a/main.tf
+++ b/main.tf
@@ -267,11 +267,11 @@ module "cache" {
   environment = var.environment
   tags        = local.tags
 
-  create_cache_bucket     = var.cache_bucket["create"]
-  cache_bucket_prefix     = var.cache_bucket_prefix
+  create_cache_bucket                  = var.cache_bucket["create"]
+  cache_bucket_prefix                  = var.cache_bucket_prefix
   cache_bucket_name_include_account_id = var.cache_bucket_name_include_account_id
-  cache_bucket_versioning = var.cache_bucket_versioning
-  cache_expiration_days   = var.cache_expiration_days
+  cache_bucket_versioning              = var.cache_bucket_versioning
+  cache_expiration_days                = var.cache_expiration_days
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -263,8 +263,8 @@ variable "cache_bucket_prefix" {
 
 variable "cache_bucket_name_include_account_id" {
   description = "Boolean to add current account ID to cache bucket name."
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "cache_bucket_versioning" {

--- a/variables.tf
+++ b/variables.tf
@@ -261,6 +261,12 @@ variable "cache_bucket_prefix" {
   default     = ""
 }
 
+variable "cache_bucket_name_include_account_id" {
+  description = "Boolean to add current account ID to cache bucket name."
+  type        = string
+  default     = "true"
+}
+
 variable "cache_bucket_versioning" {
   description = "Boolean used to enable versioning on the cache bucket, false by default."
   type        = bool


### PR DESCRIPTION
## Description

The IAM roles that we use for deployment require us to use certain resource name prefixes, along with the account ID and suffix this was pushing the cache bucket name over the 63 character limit imposed by AWS.
I have added an input variable to make the account ID in the bucket name optional as we did not require it, but wanted to maintain backwards compatibility for others.

## Migrations required
NO

## Verification

We have deployed the module to our environments.

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
