### PR TITLE
Add MaxBuilds variable to gitlab runner config

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ terraform destroy
 | runners\_idle\_time | Idle time of the runners, will be used in the runner config.toml. | number | `"600"` | no |
 | runners\_image | Image to run builds, will be used in the runner config.toml | string | `"docker:18.03.1-ce"` | no |
 | runners\_limit | Limit for the runners, will be used in the runner config.toml. | number | `"0"` | no |
+| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | bool | `"false"` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | string | n/a | yes |
 | runners\_off\_peak\_idle\_count | Off peak idle count of the runners, will be used in the runner config.toml. | number | `"0"` | no |

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ terraform destroy
 | runners\_idle\_time | Idle time of the runners, will be used in the runner config.toml. | number | `"600"` | no |
 | runners\_image | Image to run builds, will be used in the runner config.toml | string | `"docker:18.03.1-ce"` | no |
 | runners\_limit | Limit for the runners, will be used in the runner config.toml. | number | `"0"` | no |
-| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. | number | `"0"` | no |
+| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. By default set to 0, no maxBuilds will be set in the configuration. | number | `"0"` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | bool | `"false"` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | string | n/a | yes |
 | runners\_off\_peak\_idle\_count | Off peak idle count of the runners, will be used in the runner config.toml. | number | `"0"` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -45,7 +45,7 @@
 | runners\_idle\_time | Idle time of the runners, will be used in the runner config.toml. | number | `"600"` | no |
 | runners\_image | Image to run builds, will be used in the runner config.toml | string | `"docker:18.03.1-ce"` | no |
 | runners\_limit | Limit for the runners, will be used in the runner config.toml. | number | `"0"` | no |
-| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. | number | `"0"` | no |
+| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. By default set to 0, no maxBuilds will be set in the configuration. | number | `"0"` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | bool | `"false"` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | string | n/a | yes |
 | runners\_off\_peak\_idle\_count | Off peak idle count of the runners, will be used in the runner config.toml. | number | `"0"` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -45,6 +45,7 @@
 | runners\_idle\_time | Idle time of the runners, will be used in the runner config.toml. | number | `"600"` | no |
 | runners\_image | Image to run builds, will be used in the runner config.toml | string | `"docker:18.03.1-ce"` | no |
 | runners\_limit | Limit for the runners, will be used in the runner config.toml. | number | `"0"` | no |
+| runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | bool | `"false"` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | string | n/a | yes |
 | runners\_off\_peak\_idle\_count | Off peak idle count of the runners, will be used in the runner config.toml. | number | `"0"` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,9 @@ locals {
   // Ensure off peak is optional
   runners_off_peak_periods_string = var.runners_off_peak_periods == "" ? "" : format("OffPeakPeriods = %s", var.runners_off_peak_periods)
 
+  // Ensure max builds is optional
+  runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
+
   // Define key for runner token for SSM
   secure_parameter_store_runner_token_key = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
 

--- a/main.tf
+++ b/main.tf
@@ -168,6 +168,7 @@ data "template_file" "runners" {
     runners_pull_policy               = var.runners_pull_policy
     runners_idle_count                = var.runners_idle_count
     runners_idle_time                 = var.runners_idle_time
+    runners_max_builds                = local.runners_max_builds_string
     runners_off_peak_timezone         = var.runners_off_peak_timezone
     runners_off_peak_idle_count       = var.runners_off_peak_idle_count
     runners_off_peak_idle_time        = var.runners_off_peak_idle_time

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -32,6 +32,7 @@ check_interval = 0
   [runners.machine]
     IdleCount = ${runners_idle_count}
     IdleTime = ${runners_idle_time}
+    ${runners_max_builds}
     MachineDriver = "amazonec2"
     MachineName = "runner-%s"
     MachineOptions = [

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "runners_idle_count" {
 }
 
 variable "runners_max_builds" {
-  description = "Max builds for each runner after which it will be removed, will be used in the runner config.toml."
+  description = "Max builds for each runner after which it will be removed, will be used in the runner config.toml. By default set to 0, no maxBuilds will be set in the configuration."
   type        = number
   default     = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "runners_idle_count" {
   default     = 0
 }
 
+variable "runners_max_builds" {
+  description = "Max builds for each runner after which it will be removed, will be used in the runner config.toml."
+  type        = number
+  default     = 0
+}
+
 variable "runners_image" {
   description = "Image to run builds, will be used in the runner config.toml"
   type        = string


### PR DESCRIPTION
## Description
Adds the Gitlab Runner `MaxBuild` configuration option, which terminates instances that have run a certain number of builds.

## Migrations required
NO 

## Verification
Ran `runner-default` which works with both `0` `MaxBuild` (which disables the option) and `1` `MaxBuild` where the instance is destroyed after 1 build.

## Documentation
Updated :)