### PR TITLE
Allow for configurable root block size

### DIFF
--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -25,6 +25,7 @@
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | bool | `"false"` | no |
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | bool | `"true"` | no |
 | enable\_runner\_user\_data\_trace\_log | Enable bash xtrace for the user data script that creates the EC2 instance for the runner agent. Be aware this could log sensitive data such as you GitLab runner token. | bool | `"false"` | no |
+| enable\_schedule | Flag used to enable/disable auto scaling group schedule for the runner instance. | bool | `"false"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | gitlab\_runner\_registration\_config | Configuration used to register the runner. See the README for an example, or reference the examples in the examples directory of this repo. | map(string) | `<map>` | no |
 | gitlab\_runner\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the gitlab runner instance. | list(string) | `<list>` | no |
@@ -35,6 +36,7 @@
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
+| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `iops` | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
@@ -63,6 +65,7 @@
 | runners\_shm\_size | shm_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | bool | `"true"` | no |
+| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable_schedule is set to true. | map | `<map>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_key\_pair | Set this to use existing AWS key pair | string | `""` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,11 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
   instance_type        = var.instance_type
   spot_price           = var.runner_instance_spot_price
   iam_instance_profile = aws_iam_instance_profile.instance.name
+  root_block_device {
+    volume_type = "${var.ec2_volume_type}"
+    volume_size = "${var.ec2_volume_size}"
+
+  }
 
   associate_public_ip_address = false == var.runners_use_private_address
 

--- a/main.tf
+++ b/main.tf
@@ -266,10 +266,14 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
   instance_type        = var.instance_type
   spot_price           = var.runner_instance_spot_price
   iam_instance_profile = aws_iam_instance_profile.instance.name
-  root_block_device {
-    volume_type = "${var.ec2_volume_type}"
-    volume_size = "${var.ec2_volume_size}"
-
+  dynamic "root_block_device" {
+    for_each = [var.runner_root_block_device]
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", true)
+      volume_type           = lookup(root_block_device.value, "volume_type", "gp2")
+      volume_size           = lookup(root_block_device.value, "volume_size", 8)
+      iops                  = lookup(root_block_device.value, "iops", null)
+    }
   }
 
   associate_public_ip_address = false == var.runners_use_private_address

--- a/variables.tf
+++ b/variables.tf
@@ -445,5 +445,5 @@ variable "ec2_volume_type" {
 
 variable "ec2_volume_size" {
   description = "The size of the root volume of the EC2 instance used for the runners"
-  default = 8
+  default     = 8
 }

--- a/variables.tf
+++ b/variables.tf
@@ -437,3 +437,12 @@ variable "enable_runner_user_data_trace_log" {
   type        = bool
   default     = false
 }
+
+variable "ec2_volume_type" {
+  description = "The type of volume used for the root volume of the EC2 instance used for the runners"
+  default     = "gp2"
+}
+
+variable "ec2_volume_size" {
+  description = "The size of the root volume of the EC2 instance used for the runners"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -445,4 +445,5 @@ variable "ec2_volume_type" {
 
 variable "ec2_volume_size" {
   description = "The size of the root volume of the EC2 instance used for the runners"
+  default = 8
 }

--- a/variables.tf
+++ b/variables.tf
@@ -438,16 +438,6 @@ variable "enable_runner_user_data_trace_log" {
   default     = false
 }
 
-variable "ec2_volume_type" {
-  description = "The type of volume used for the root volume of the EC2 instance used for the runners"
-  default     = "gp2"
-}
-
-variable "ec2_volume_size" {
-  description = "The size of the root volume of the EC2 instance used for the runners"
-  default     = 8
-}
-
 variable "enable_schedule" {
   description = "Flag used to enable/disable auto scaling group schedule for the runner instance. "
   type        = bool
@@ -465,3 +455,8 @@ variable "schedule_config" {
   }
 }
 
+variable "runner_root_block_device" {
+  description = "The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `iops`"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description
This fixes https://github.com/npalm/terraform-aws-gitlab-runner/issues/80 by allowing to use specific/dedicated input variables for configuring the EBS volume types and size attached to the instance.

## Migrations required
YES - while I'm setting the default to `8`GB drift might still be created depending on the existing/running launch configuration.

## Verification
`plan` and `apply`.

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
