### PR TITLE
Bump gitlab-runner to 12.2.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -294,7 +294,7 @@ variable "cache_shared" {
 variable "gitlab_runner_version" {
   description = "Version of the GitLab runner."
   type        = string
-  default     = "12.1.0"
+  default     = "12.2.0"
 }
 
 variable "enable_gitlab_runner_ssh_access" {
@@ -365,7 +365,6 @@ variable "ami_owners" {
   type        = list(string)
   default     = ["amazon"]
 }
-
 
 variable "runner_ami_filter" {
   description = "List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI."


### PR DESCRIPTION
## Description
Bump gitlab-runner to 12.2.0.

## Migrations required
NO

## Verification
Tested on personal infra.

## Documentation
OK
