### PR TITLE
Bump gitlab-runner to 12.3.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -294,7 +294,7 @@ variable "cache_shared" {
 variable "gitlab_runner_version" {
   description = "Version of the GitLab runner."
   type        = string
-  default     = "12.2.0"
+  default     = "12.3.0"
 }
 
 variable "enable_gitlab_runner_ssh_access" {


### PR DESCRIPTION
## Description
Bump gitlab-runner to 12.3.0. That released at Sep 09

## Migrations required
NO

## Verification
Tested on personal infra

## Documentation
Ok