### PR TITLE
Additon Options to specify tmpfs volumes in main and service containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Finally, the runner still supports the manual runner creation. No changes are re
 
 By default the module creates a a cache for the runner in S3. Old objects are automatically remove via a configurable life cycle policy on the bucket.
 
-Creation of the bucket can be disabled and managed outside this module. A good use case is for sharing the cache cross multiple runners. For this purpose the cache is implemented as sub module. For more details see the [cache module](https://github.com/npalm/terraform-aws-gitlab-runner/tree/terraform011/cache). An example implementation of this use case can be find in the [runner-public](https://github.com/npalm/terraform-aws-gitlab-runner/tree/__GIT_REF__/examples/runner-public) example.
+Creation of the bucket can be disabled and managed outside this module. A good use case is for sharing the cache cross multiple runners. For this purpose the cache is implemented as sub module. For more details see the [cache module](https://github.com/npalm/terraform-aws-gitlab-runner/tree/develop/cache). An example implementation of this use case can be find in the [runner-public](https://github.com/npalm/terraform-aws-gitlab-runner/tree/__GIT_REF__/examples/runner-public) example.
 
 ## Usage
 
@@ -145,7 +145,7 @@ The base image used to host the GitLab Runner agent is the latest available Amaz
 
 ### Usage module
 
-Below a basic examples of usages of the module. The dependencies such as a VPC, and SSH keys have a look at the [default example](https://github.com/npalm/terraform-aws-gitlab-runner/tree/terraform011/examples/runner-default).
+Below a basic examples of usages of the module. The dependencies such as a VPC, and SSH keys have a look at the [default example](https://github.com/npalm/terraform-aws-gitlab-runner/tree/develop/examples/runner-default).
 
 ``` hcl
 
@@ -178,7 +178,7 @@ module "runner" {
 
 ## Examples
 
-A few \[examples\]([examples](https://github.com/npalm/terraform-aws-gitlab-runner/tree/terraform011/examples/) are provided. Use the following steps to deploy. Ensure your AWS and Terraform environment is set up correctly. All commands below should be run from the `terraform-aws-gitlab-runner/examples/<example-dir>` directory.
+A few \[examples\]([examples](https://github.com/npalm/terraform-aws-gitlab-runner/tree/develop/examples/) are provided. Use the following steps to deploy. Ensure your AWS and Terraform environment is set up correctly. All commands below should be run from the `terraform-aws-gitlab-runner/examples/<example-dir>` directory.
 
 ### SSH keys
 
@@ -270,10 +270,12 @@ terraform destroy
 | runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
+| runners\_services\_volumes\_tmpfs |  | list | `<list>` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
 | runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
+| runners\_volumes\_tmpfs |  | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
@@ -287,6 +289,7 @@ terraform destroy
 
 | Name | Description |
 |------|-------------|
+| bla |  |
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |

--- a/README.md
+++ b/README.md
@@ -270,12 +270,12 @@ terraform destroy
 | runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
-| runners\_services\_volumes\_tmpfs |  | list | `<list>` | no |
+| runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
 | runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
-| runners\_volumes\_tmpfs |  | list | `<list>` | no |
+| runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
@@ -289,7 +289,6 @@ terraform destroy
 
 | Name | Description |
 |------|-------------|
-| bla |  |
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -58,12 +58,12 @@
 | runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
-| runners\_services\_volumes\_tmpfs |  | list | `<list>` | no |
+| runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
 | runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
-| runners\_volumes\_tmpfs |  | list | `<list>` | no |
+| runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
@@ -77,7 +77,6 @@
 
 | Name | Description |
 |------|-------------|
-| bla |  |
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -58,10 +58,12 @@
 | runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
+| runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | no
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
 | runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
+| runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | no
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -58,12 +58,12 @@
 | runners\_pull\_policy | pull_policy for the runners.  will be used in the runner config.toml | string | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | string | `"1"` | no |
 | runners\_root\_size | Runner instance root size in GB. | string | `"16"` | no |
-| runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | no
+| runners\_services\_volumes\_tmpfs |  | list | `<list>` | no |
 | runners\_shm\_size | shm_size for the runners.  will be used in the runner config.toml | string | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | string | `"true"` | no |
 | runners\_volumes | Specify additional volumes that should be mounted (same syntax as Docker’s -v flag) | list | `<list>` | no |
-| runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | no
+| runners\_volumes\_tmpfs |  | list | `<list>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | n/a | yes |
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
@@ -77,6 +77,7 @@
 
 | Name | Description |
 |------|-------------|
+| bla |  |
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -48,13 +48,13 @@ module "runner" {
     maximum_timeout    = "3600"
   }
 
-  runners_volumes_tmpfs = {
-    "/var/opt/cache" = "rw,noexec"
-  }
+  runners_volumes_tmpfs = [
+    { "/var/opt/cache" = "rw,noexec"},
+  ]
 
-  runners_services_volumes_tmpfs = {
-    "/var/lib/mysql" = "rw,noexec"
-  }
+  runners_services_volumes_tmpfs = [
+    { "/var/lib/mysql" = "rw,noexec" },
+  ]
 
   runners_off_peak_timezone   = "${var.timezone}"
   runners_off_peak_idle_count = 0

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -48,6 +48,10 @@ module "runner" {
     maximum_timeout    = "3600"
   }
 
+  runners_volumes_tmpfs = {
+    "/var/opt/cache" = "rw,noexec"
+  }
+
   runners_services_volumes_tmpfs = {
     "/var/lib/mysql" = "rw,noexec"
   }

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -48,6 +48,10 @@ module "runner" {
     maximum_timeout    = "3600"
   }
 
+  runners_services_volumes_tmpfs = {
+    "/var/lib/mysql" = "rw,noexec"
+  }
+
   runners_off_peak_timezone   = "${var.timezone}"
   runners_off_peak_idle_count = 0
   runners_off_peak_idle_time  = 60

--- a/main.tf
+++ b/main.tf
@@ -183,11 +183,6 @@ data "template_file" "runners" {
     runners_volumes                   = "${length(var.runners_volumes) == 0 ? "[]" : format("[\"%s\"]", join("\", \"", var.runners_volumes))}"
     runners_volumes_tmpfs             = "${chomp(join("", data.template_file.volumes_tmpfs.*.rendered))}"
     runners_services_volumes_tmpfs    = "${chomp(join("", data.template_file.services_volumes_tmpfs.*.rendered))}"
-    #runners_volumes_tmpfs             = "${join("\n", var.runners_services_volumes_tmpfs)}"
-    #runners_services_volumes_tmpfs    = ""
-
-
-    #${join(",", data.template_file.data_json.*.rendered)
     runners_shm_size                  = "${var.runners_shm_size}"
     runners_pull_policy               = "${var.runners_pull_policy}"
     runners_idle_count                = "${var.runners_idle_count}"

--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,24 @@ data "template_file" "gitlab_runner" {
   }
 }
 
+data "template_file" "services_volumes_tmpfs" {
+  template = "${file("${path.module}/template/volumes.tpl")}"
+  count    = "${length(var.runners_services_volumes_tmpfs)}"
+  vars {
+    volume = "${element(keys(var.runners_services_volumes_tmpfs[count.index]), 0)}"
+    options = "${element(values(var.runners_services_volumes_tmpfs[count.index]), 0)}"
+  }
+}
+
+data "template_file" "volumes_tmpfs" {
+  template = "${file("${path.module}/template/volumes.tpl")}"
+  count    = "${length(var.runners_volumes_tmpfs)}"
+  vars {
+    volume = "${element(keys(var.runners_volumes_tmpfs[count.index]), 0)}"
+    options = "${element(values(var.runners_volumes_tmpfs[count.index]), 0)}"
+  }
+}
+
 data "template_file" "runners" {
   template = "${file("${path.module}/template/runner-config.tpl")}"
 
@@ -163,6 +181,13 @@ data "template_file" "runners" {
     runners_image                     = "${var.runners_image}"
     runners_privileged                = "${var.runners_privileged}"
     runners_volumes                   = "${length(var.runners_volumes) == 0 ? "[]" : format("[\"%s\"]", join("\", \"", var.runners_volumes))}"
+    runners_volumes_tmpfs             = "${chomp(join("", data.template_file.volumes_tmpfs.*.rendered))}"
+    runners_services_volumes_tmpfs    = "${chomp(join("", data.template_file.services_volumes_tmpfs.*.rendered))}"
+    #runners_volumes_tmpfs             = "${join("\n", var.runners_services_volumes_tmpfs)}"
+    #runners_services_volumes_tmpfs    = ""
+
+
+    #${join(",", data.template_file.data_json.*.rendered)
     runners_shm_size                  = "${var.runners_shm_size}"
     runners_pull_policy               = "${var.runners_pull_policy}"
     runners_idle_count                = "${var.runners_idle_count}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,7 +17,3 @@ output "runner_role" {
   description = "ARN of the rule used for the docker machine runners."
   value       = "${aws_iam_role.docker_machine.arn}"
 }
-
-output "bla" {
-  value = "${data.template_file.runners.rendered}"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "runner_role" {
   description = "ARN of the rule used for the docker machine runners."
   value       = "${aws_iam_role.docker_machine.arn}"
 }
+
+output "bla" {
+  value = "${data.template_file.runners.rendered}"
+}

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -21,6 +21,10 @@ check_interval = 0
     volumes = ${runners_volumes}
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
+  [runners.docker.tmpfs]
+${runners_volumes_tmpfs}
+  [runners.docker.services_tmpfs]
+${runners_services_volumes_tmpfs}
   [runners.cache]
     Type = "s3"
     Shared = ${shared_cache}

--- a/template/volumes.tpl
+++ b/template/volumes.tpl
@@ -1,0 +1,1 @@
+    "${volume}" = "${options}"

--- a/variables.tf
+++ b/variables.tf
@@ -122,12 +122,14 @@ variable "runners_volumes" {
 }
 
 variable "runners_volumes_tmpfs" {
+  description = "Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. \"/var/lib/mysql\" = \"rw,noexec\", see example"
   type = "list"
   default = []
 }
 
 
 variable "runners_services_volumes_tmpfs" {
+  description = "Mount temporary file systems to service containers. Must consist of pairs of strings e.g. \"/var/lib/mysql\" = \"rw,noexec\", see example"
   type = "list"
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -124,20 +124,12 @@ variable "runners_volumes" {
 variable "runners_volumes_tmpfs" {
   type = "list"
   default = []
-  # default = [
-  #   { "/var/lib/postgresql" = "rw,noexec" },
-  #   { "/cache1" = "rw,noexec"},
-  # ]
 }
 
 
 variable "runners_services_volumes_tmpfs" {
   type = "list"
   default = []
-  # default = [
-  #   { "/var/lib/mysql" = "rw,noexec" },
-  #   { "/cache2" = "rw,noexec"},
-  # ]
 }
 
 variable "runners_shm_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,25 @@ variable "runners_volumes" {
   default     = ["/cache"]
 }
 
+variable "runners_volumes_tmpfs" {
+  type = "list"
+  default = []
+  # default = [
+  #   { "/var/lib/postgresql" = "rw,noexec" },
+  #   { "/cache1" = "rw,noexec"},
+  # ]
+}
+
+
+variable "runners_services_volumes_tmpfs" {
+  type = "list"
+  default = []
+  # default = [
+  #   { "/var/lib/mysql" = "rw,noexec" },
+  #   { "/cache2" = "rw,noexec"},
+  # ]
+}
+
 variable "runners_shm_size" {
   description = "shm_size for the runners.  will be used in the runner config.toml"
   default     = 0


### PR DESCRIPTION
## Description
Closes #104 
Adds the ability to add temporary file systems to main and service containers.

A few sentences describing the overall goals of the pull request's commits.

## Migrations required
NO. Defaults are empty and work out of the box.

## Verification
- Verified, that Gitlab Runner starts with 0,1 and 2 Different temporary Volumes in main and service container
- Verified by running `ci/bin/run-local.sh`

## Documentation
Documentation has been updated
