### PR TITLE
Adding outputs for agent and runner security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,5 @@ terraform destroy
 | runner\_cache\_bucket\_name | Name of the S3 for the build cache. |
 | runner\_role\_arn | ARN of the role used for the docker machine runners. |
 | runner\_role\_name | Name of the role used for the docker machine runners. |
+| runner\_agent\_sg\_id | ID of the security group attached to the GitLab runner agent. |
+| runner\_sg\_id | ID of the security group attached to the docker machine runners. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,15 @@ output "runner_role_name" {
   description = "Name of the role used for the docker machine runners."
   value       = aws_iam_role.docker_machine.name
 }
+
+output "runner_agent_sg_id" {
+  description = "ID of the security group attached to the GitLab runner agent."
+  value       = aws_security_group.runner.id
+}
+
+output "runner_sg_id" {
+  description = "ID of the security group used to the docker machine runners."
+  value       = aws_security_group.docker_machine.id
+}
+
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,8 +39,6 @@ output "runner_agent_sg_id" {
 }
 
 output "runner_sg_id" {
-  description = "ID of the security group used to the docker machine runners."
+  description = "ID of the security group attached to the docker machine runners."
   value       = aws_security_group.docker_machine.id
 }
-
-


### PR DESCRIPTION
## Description
Just adding outputs for a security group IDs to simplify integration of resources created by this module with existing network setups.

## Migrations required
NO

## Verification
The default example is working, others should be working too.

## Documentation
Added new outputs to docs.
