### PR TITLE
Add variable docker_machine_docker_cidr_blocks allowing docker ingress restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ terraform destroy
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | bool | `"true"` | no |
+| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -14,6 +14,7 @@
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | bool | `"true"` | no |
+| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
@@ -88,4 +89,3 @@
 | runner\_cache\_bucket\_name | Name of the S3 for the build cache. |
 | runner\_role\_arn | ARN of the role used for the docker machine runners. |
 | runner\_role\_name | Name of the role used for the docker machine runners. |
-

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_security_group_rule" "docker_machine_docker" {
   from_port   = 2376
   to_port     = 2376
   protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.docker_machine_docker_cidr_blocks
 
   security_group_id = aws_security_group.docker_machine.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -309,6 +309,12 @@ variable "gitlab_runner_ssh_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "docker_machine_docker_cidr_blocks" {
+  description = "List of CIDR blocks to allow Docker Access to the docker machine runner instance."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "docker_machine_ssh_cidr_blocks" {
   description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance."
   type        = list(string)


### PR DESCRIPTION
## Description
Related to https://github.com/npalm/terraform-aws-gitlab-runner/pull/101, make the ingress CIDR configurable for the docker port 2376 security group rule.

## Migrations required
No, default value of the new variable is the original value.