### PR TITLE
Lock down docker port access to only the runner security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,12 +47,22 @@ resource "aws_security_group" "docker_machine" {
   )
 }
 
-resource "aws_security_group_rule" "docker_machine_docker" {
-  type        = "ingress"
-  from_port   = 2376
-  to_port     = 2376
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+resource "aws_security_group_rule" "docker_machine_docker_runner" {
+  type                     = "ingress"
+  from_port                = 2376
+  to_port                  = 2376
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.runner.id
+
+  security_group_id = aws_security_group.docker_machine.id
+}
+
+resource "aws_security_group_rule" "docker_machine_docker_self" {
+  type      = "ingress"
+  from_port = 2376
+  to_port   = 2376
+  protocol  = "tcp"
+  self      = true
 
   security_group_id = aws_security_group.docker_machine.id
 }


### PR DESCRIPTION
## Description
Alternative to https://github.com/npalm/terraform-aws-gitlab-runner/pull/139 as I dont think we need to expose the docker port to the world. Just to the gitlab runner instance and maybe the other docker machines?

## Migrations required
NO