### PR TITLE
Add option to limit docker machine ssh ingress access to only the runner

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ data "template_file" "runners" {
     runners_root_size                 = var.runners_root_size
     runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
     runners_use_private_address_only  = var.runners_use_private_address
-    runners_use_private_address       = var.runners_use_private_address ? false : true
+    runners_use_private_address       = ! var.runners_use_private_address
     runners_environment_vars          = jsonencode(var.runners_environment_vars)
     runners_pre_build_script          = var.runners_pre_build_script
     runners_post_build_script         = var.runners_post_build_script

--- a/main.tf
+++ b/main.tf
@@ -47,18 +47,6 @@ resource "aws_security_group" "docker_machine" {
   )
 }
 
-resource "aws_security_group_rule" "docker_machine_docker_external" {
-  count = var.runners_use_private_address ? 0 : 1
-
-  type        = "ingress"
-  from_port   = 2376
-  to_port     = 2376
-  protocol    = "tcp"
-  cidr_blocks = var.docker_machine_docker_cidr_blocks
-
-  security_group_id = aws_security_group.docker_machine.id
-}
-
 resource "aws_security_group_rule" "docker_machine_docker_runner" {
   type                     = "ingress"
   from_port                = 2376
@@ -75,18 +63,6 @@ resource "aws_security_group_rule" "docker_machine_docker_self" {
   to_port   = 2376
   protocol  = "tcp"
   self      = true
-
-  security_group_id = aws_security_group.docker_machine.id
-}
-
-resource "aws_security_group_rule" "docker_machine_ssh_external" {
-  count = var.runners_use_private_address ? 0 : 1
-
-  type        = "ingress"
-  from_port   = 22
-  to_port     = 22
-  protocol    = "tcp"
-  cidr_blocks = var.docker_machine_ssh_cidr_blocks
 
   security_group_id = aws_security_group.docker_machine.id
 }
@@ -238,7 +214,8 @@ data "template_file" "runners" {
     runners_off_peak_periods_string   = local.runners_off_peak_periods_string
     runners_root_size                 = var.runners_root_size
     runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
-    runners_use_private_address       = var.runners_use_private_address
+    runners_use_private_address_only  = var.runners_use_private_address
+    runners_use_private_address       = var.runners_use_private_address ? false : true
     runners_environment_vars          = jsonencode(var.runners_environment_vars)
     runners_pre_build_script          = var.runners_pre_build_script
     runners_post_build_script         = var.runners_post_build_script

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,18 @@ resource "aws_security_group" "docker_machine" {
   )
 }
 
+resource "aws_security_group_rule" "docker_machine_docker_external" {
+  count = var.runners_use_private_address ? 0 : 1
+
+  type        = "ingress"
+  from_port   = 2376
+  to_port     = 2376
+  protocol    = "tcp"
+  cidr_blocks = var.docker_machine_docker_cidr_blocks
+
+  security_group_id = aws_security_group.docker_machine.id
+}
+
 resource "aws_security_group_rule" "docker_machine_docker_runner" {
   type                     = "ingress"
   from_port                = 2376
@@ -63,6 +75,18 @@ resource "aws_security_group_rule" "docker_machine_docker_self" {
   to_port   = 2376
   protocol  = "tcp"
   self      = true
+
+  security_group_id = aws_security_group.docker_machine.id
+}
+
+resource "aws_security_group_rule" "docker_machine_ssh_external" {
+  count = var.runners_use_private_address ? 0 : 1
+
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = var.docker_machine_ssh_cidr_blocks
 
   security_group_id = aws_security_group.docker_machine.id
 }

--- a/main.tf
+++ b/main.tf
@@ -67,21 +67,7 @@ resource "aws_security_group_rule" "docker_machine_docker_self" {
   security_group_id = aws_security_group.docker_machine.id
 }
 
-resource "aws_security_group_rule" "docker_machine_ssh" {
-  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 0 : 1
-
-  type        = "ingress"
-  from_port   = 22
-  to_port     = 22
-  protocol    = "tcp"
-  cidr_blocks = var.docker_machine_ssh_cidr_blocks
-
-  security_group_id = aws_security_group.docker_machine.id
-}
-
 resource "aws_security_group_rule" "docker_machine_ssh_runner" {
-  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 1 : 0
-
   type                     = "ingress"
   from_port                = 22
   to_port                  = 22
@@ -92,8 +78,6 @@ resource "aws_security_group_rule" "docker_machine_ssh_runner" {
 }
 
 resource "aws_security_group_rule" "docker_machine_ssh_self" {
-  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 1 : 0
-
   type      = "ingress"
   from_port = 22
   to_port   = 22

--- a/main.tf
+++ b/main.tf
@@ -68,11 +68,37 @@ resource "aws_security_group_rule" "docker_machine_docker_self" {
 }
 
 resource "aws_security_group_rule" "docker_machine_ssh" {
+  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 0 : 1
+
   type        = "ingress"
   from_port   = 22
   to_port     = 22
   protocol    = "tcp"
   cidr_blocks = var.docker_machine_ssh_cidr_blocks
+
+  security_group_id = aws_security_group.docker_machine.id
+}
+
+resource "aws_security_group_rule" "docker_machine_ssh_runner" {
+  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.runner.id
+
+  security_group_id = aws_security_group.docker_machine.id
+}
+
+resource "aws_security_group_rule" "docker_machine_ssh_self" {
+  count = var.docker_machine_ssh_restrict_ingress_to_runner ? 1 : 0
+
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+  self      = true
 
   security_group_id = aws_security_group.docker_machine.id
 }

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -21,7 +21,7 @@ check_interval = 0
     volumes = ["/cache"${runners_additional_volumes}]
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
-  [runners.docker.tmpfs] 
+  [runners.docker.tmpfs]
     ${runners_volumes_tmpfs}
   [runners.docker.services_tmpfs]
     ${runners_services_volumes_tmpfs}
@@ -45,7 +45,8 @@ check_interval = 0
       "amazonec2-zone=${runners_aws_zone}",
       "amazonec2-vpc-id=${runners_vpc_id}",
       "amazonec2-subnet-id=${runners_subnet_id}",
-      "amazonec2-private-address-only=${runners_use_private_address}",
+      "amazonec2-private-address-only=${runners_use_private_address_only}",
+      "amazonec2-use-private-address=${runners_use_private_address}",
       "amazonec2-request-spot-instance=true",
       "amazonec2-spot-price=${runners_spot_price_bid}",
       "amazonec2-security-group=${runners_security_group_name}",

--- a/variables.tf
+++ b/variables.tf
@@ -309,6 +309,18 @@ variable "gitlab_runner_ssh_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "docker_machine_docker_cidr_blocks" {
+  description = "List of CIDR blocks to allow Docker Access to the docker machine runner instance. Only relevant for public facing machines (when runners_use_private_address is false)."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "docker_machine_ssh_cidr_blocks" {
+  description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance. Only relevant for public facing machines (when runners_use_private_address is false)."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "enable_cloudwatch_logging" {
   description = "Boolean used to enable or disable the CloudWatch logging."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -309,16 +309,16 @@ variable "gitlab_runner_ssh_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "docker_machine_docker_cidr_blocks" {
-  description = "List of CIDR blocks to allow Docker Access to the docker machine runner instance."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
 variable "docker_machine_ssh_cidr_blocks" {
   description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance."
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+variable "docker_machine_ssh_restrict_ingress_to_runner" {
+  description = "Instead of using cidr blocks to control docker machine SSH ingress access, limit access to only the runner via its security group"
+  type        = bool
+  default     = false
 }
 
 variable "enable_cloudwatch_logging" {

--- a/variables.tf
+++ b/variables.tf
@@ -309,18 +309,6 @@ variable "gitlab_runner_ssh_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "docker_machine_ssh_cidr_blocks" {
-  description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
-variable "docker_machine_ssh_restrict_ingress_to_runner" {
-  description = "Instead of using cidr blocks to control docker machine SSH ingress access, limit access to only the runner via its security group"
-  type        = bool
-  default     = false
-}
-
 variable "enable_cloudwatch_logging" {
   description = "Boolean used to enable or disable the CloudWatch logging."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -309,18 +309,6 @@ variable "gitlab_runner_ssh_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "docker_machine_docker_cidr_blocks" {
-  description = "List of CIDR blocks to allow Docker Access to the docker machine runner instance. Only relevant for public facing machines (when runners_use_private_address is false)."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
-variable "docker_machine_ssh_cidr_blocks" {
-  description = "List of CIDR blocks to allow SSH Access to the docker machine runner instance. Only relevant for public facing machines (when runners_use_private_address is false)."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
 variable "enable_cloudwatch_logging" {
   description = "Boolean used to enable or disable the CloudWatch logging."
   type        = bool


### PR DESCRIPTION
## Description
Similar to https://github.com/npalm/terraform-aws-gitlab-runner/pull/140, limit the docker machine ssh ingress access to only the runner via security groups instead of cidr ranges.

I kept backwards compatibility by making this feature optional (defaults to false) as I do not know if people actually need external SSH access to the docker machines. @npalm Do you think external SSH access is necessary? If it doesnt make sense, we could remove the CIDR based security rule and simply the code. Otherwise, this should work to support both cases.

## Migrations required
No