### PR TITLE
Remove docker_machine_user variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -255,12 +255,6 @@ variable "runners_use_private_address" {
   default     = true
 }
 
-variable "docker_machine_user" {
-  description = "Username of the user used to create the spot instances that host docker-machine."
-  type        = string
-  default     = "docker-machine"
-}
-
 variable "cache_bucket_prefix" {
   description = "Prefix for s3 cache bucket name."
   type        = string


### PR DESCRIPTION
This was in the original version of the module and appears to be no
longer used.

## Migrations required
NO

## Verification
Just did grep -r to confirm the var isn't used anywhere.

## Documentation
Not mentioned in doco so nothing to update.
