### PR TITLE
fix type create cache bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,10 @@ terraform destroy
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | bool | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
-| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
-| docker\_machine\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | bool | `"true"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | bool | `"false"` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -13,12 +13,10 @@
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | bool | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
-| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
-| docker\_machine\_ssh\_cidr\_blocks | List of CIDR blocks to allow SSH Access to the docker machine runner instance. | list(string) | `<list>` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | bool | `"true"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | bool | `"false"` | no |

--- a/cache/README.md
+++ b/cache/README.md
@@ -33,7 +33,7 @@ module "runner" {
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | string | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
-| create\_cache\_bucket | This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled. | string | `"true"` | no |
+| create\_cache\_bucket | This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled. | bool | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | map(string) | `<map>` | no |
 

--- a/cache/_docs/TF_MODULE.md
+++ b/cache/_docs/TF_MODULE.md
@@ -6,7 +6,7 @@
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | string | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | number | `"1"` | no |
-| create\_cache\_bucket | This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled. | string | `"true"` | no |
+| create\_cache\_bucket | This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled. | bool | `"true"` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | string | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | map(string) | `<map>` | no |
 

--- a/cache/main.tf
+++ b/cache/main.tf
@@ -1,6 +1,4 @@
-data "aws_caller_identity" "current" {
-  count = var.create_cache_bucket ? 1 : 0
-}
+data "aws_caller_identity" "current" {}
 
 locals {
   tags = merge(
@@ -13,7 +11,7 @@ locals {
     var.tags,
   )
 
-  cache_bucket_name = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
+  cache_bucket_name = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current.account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
 }
 
 resource "aws_s3_bucket" "build_cache" {
@@ -73,4 +71,3 @@ resource "aws_iam_policy" "docker_machine_cache" {
 
   policy = data.template_file.docker_machine_cache_policy[0].rendered
 }
-

--- a/cache/variables.tf
+++ b/cache/variables.tf
@@ -35,6 +35,6 @@ variable "tags" {
 
 variable "create_cache_bucket" {
   description = "This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled."
-  type        = string
+  type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description
Fix bad type and possible race condition/intermittent failures. 

The cache module would fail on some of our developer's laptops. Currently, you optionally call `data.aws_caller_identity` if `create_cache_bucket` is set to true. `create_cache_bucket` defaults to `bool` true but has an improper type of `string`. This likely doesn't matter bc of loose automatic terraform type-conversion but should get fixed.  You then optionally decide to prefix the bucket with the account-id if `cache_bucket_name_include_account_id` is set to true. `cache_bucket_name_include_account_id` has a correct bool type. There is a chance for these invariants to not line up - i.e. dont create the cache bucket but ask for it to add the account_id to the bucket name.

 _That said, in our case, we were leaving these as the defaults and we still experienced intermittent failures below on some developer's laptops._ There may be some race condition that causes the `data.aws_caller_identity` tuple to not be populated and then terraform attempts to use it for templating the bucket name. I didnt investigate much further but tested the fork on a number of our team members machines that were experiencing the failure and it consistently seemed to address the issue.

This commit fixes the type of `create_cache_bucket` and sets it to `bool`. It also, removes the `count` attribute on `data.aws_caller_identity`. The identity will always be looked up but only used in the case that `cache_bucket_name_include_account_id` is true. This is a small performance hit but in reality, the optimization seemed a little overzealous.

```
Error: Invalid index
  on .terraform/modules/runner.runner/npalm-terraform-aws-gitlab-runner-43ebd78/cache/main.tf line 16, in locals:
  16:   cache_bucket_name = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current[0].account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
    |----------------
    | data.aws_caller_identity.current is empty tuple
The given key does not identify an element in this collection value.
```

I regenerated the docs and it picked up another change that I didnt change so it seems the docs were already slightly stale. Specifically `docker_machine_ssh_cidr_blocks` and  `docker_machine_docker_cidr_blocks` look to no longer be used.

## Migrations required
NO 

https://www.terraform.io/docs/configuration/expressions.html#type-conversion

## Verification
Tested a very simple deploy of a cache and gitlab runner with mostly defaults

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
