### PR TITLE
Fix/tokens

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -48,7 +48,7 @@ then
     --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
     --form "access_level=${gitlab_runner_access_level}" \
     | jq -r .token)
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --value $token --region "${secure_parameter_store_region}"
+  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --value="$token" --region "${secure_parameter_store_region}"
 fi
 
 sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml


### PR DESCRIPTION
## Description
Currently, if gitlab returns a token starting with `-` aws ssm fails to push and furthermore the token fails. This PR fixes it

## Migrations required
NO 
