### PR TITLE
Allow assignment of Elastic IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ terraform destroy
 | cache\_expiration\_days | Number of days before cache objects expires. | string | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | string | `"false"` | no |
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | string | `"true"` | no |
+| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
@@ -233,6 +234,7 @@ terraform destroy
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
+| enable\_eip | Enable the assignment of an EIP to the gitlab runner instance | string | `"false"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | string | `"false"` | no |
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | enable\_runner\_user\_data\_trace\_log | Enable bash xtrace for the user data script that creates the EC2 instance for the runner agent. Be aware this could log sensitive data such as you GitLab runner token. | string | `"false"` | no |
@@ -292,4 +294,5 @@ terraform destroy
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |
+| runner\_eip | EIP of the Gitlab Runner |
 | runner\_role | ARN of the rule used for the docker machine runners. |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -13,6 +13,7 @@
 | cache\_expiration\_days | Number of days before cache objects expires. | string | `"1"` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | string | `"false"` | no |
 | create\_runners\_iam\_instance\_profile | Boolean to control the creation of the runners IAM instance profile | string | `"true"` | no |
+| docker\_machine\_docker\_cidr\_blocks | List of CIDR blocks to allow Docker Access to the docker machine runner instance. | list | `<list>` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
@@ -21,6 +22,7 @@
 | docker\_machine\_user | Username of the user used to create the spot instances that host docker-machine. | string | `"docker-machine"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | string | `"true"` | no |
+| enable\_eip | Enable the assignment of an EIP to the gitlab runner instance | string | `"false"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | string | `"false"` | no |
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | string | `"true"` | no |
 | enable\_runner\_user\_data\_trace\_log | Enable bash xtrace for the user data script that creates the EC2 instance for the runner agent. Be aware this could log sensitive data such as you GitLab runner token. | string | `"false"` | no |
@@ -80,5 +82,6 @@
 | runner\_agent\_role | ARN of the rule used for the ec2 instance for the GitLab runner agent. |
 | runner\_as\_group\_name | Name of the autoscaling group for the gitlab-runner instance |
 | runner\_cache\_bucket\_arn | ARN of the S3 for the build cache. |
+| runner\_eip | EIP of the Gitlab Runner |
 | runner\_role | ARN of the rule used for the docker machine runners. |
 

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -44,4 +44,6 @@ module "runner" {
     run_untagged       = "false"
     maximum_timeout    = "3600"
   }
+
+  enable_eip = "true"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "runner_role" {
   description = "ARN of the rule used for the docker machine runners."
   value       = "${aws_iam_role.docker_machine.arn}"
 }
+
+output "runner_eip" {
+  description = "EIP of the Gitlab Runner"
+  value       = "${join(",", aws_eip.gitlab_runner.*.public_ip)}"
+}

--- a/policies/instance-eip.json
+++ b/policies/instance-eip.json
@@ -1,0 +1,13 @@
+{
+   "Version": "2012-10-17",
+   "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AssociateAddress",
+        "ec2:Describe*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/template/eip.tpl
+++ b/template/eip.tpl
@@ -1,0 +1,4 @@
+echo 'installing additional software for assigning EIP'
+pip install aws-ec2-assign-elastic-ip
+export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+/usr/local/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -11,6 +11,8 @@ tee /etc/hosts <<EOL
 127.0.0.1   localhost localhost.localdomain `hostname`
 EOL
 
+${eip}
+
 for i in {1..7}
 do
   echo "Attempt: ---- " $i
@@ -20,3 +22,4 @@ done
 ${logging}
 
 ${gitlab_runner}
+

--- a/variables.tf
+++ b/variables.tf
@@ -418,3 +418,9 @@ variable "enable_runner_user_data_trace_log" {
   description = "Enable bash xtrace for the user data script that creates the EC2 instance for the runner agent. Be aware this could log sensitive data such as you GitLab runner token."
   default     = false
 }
+
+variable "enable_eip" {
+  description = "Enable the assignment of an EIP to the gitlab runner instance"
+  default     = false
+  type        = "string"
+}


### PR DESCRIPTION
## Description
allow assignment of an elastic IP for the gitlab runner instance (mostly useful if it is run with a public IP

## Migrations required
NO. Feature is disabled by default

## Verification
Please mention the examples you have verified.

## Documentation
Documentation has been updated.