### PR TITLE
Remove runner on instance shutdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In this scenario *not* docker machine is used but docker to schedule the builds.
 
 Ensure you have Terraform installed the modules is based on Terraform 0.11, see `.terraform-version` for the used version. A handy tool to mange your Terraform version is [tfenv](https://github.com/kamatama41/tfenv).
 
-On macOS it is simple to install `tfenv` using brew.
+On macOS it is simple to install `tfenv` using `brew`.
 
 ``` sh
 brew install tfenv
@@ -71,7 +71,17 @@ tfenv install <version>
 
 ### AWS
 
-Ensure you have setup you AWS credentials. The module requires access to IAM, EC2, CloudWatch, S3 and SSM.
+Ensure you have setup your AWS credentials. The module requires access to IAM, EC2, CloudWatch, S3 and SSM.
+
+### JQ & AWS CLI
+
+In order to be able to destroy the module, you will need to run from a host with both `jq` and `aws` installed and accessible in the environment.
+
+On macOS it is simple to install them using `brew`.
+
+``` sh
+brew install jq awscli
+```
 
 ### Service linked roles
 
@@ -94,7 +104,7 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 
 ### GitLab runner token configuration
 
-By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the parameter store. See [example](examples/runner-pre-registered/) for more details.
+By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS parameter store. See [example](examples/runner-pre-registered/) for more details.
 
 To register the runner automatically set the variable `gitlab_runner_registration_config["token"]`. This token value can be found in your GitLab project, group, or global settings. For a generic runner you can find the token in the admin section. By default the runner will be locked to the target project, not run untagged. Below is an example of the configuration map.
 
@@ -110,7 +120,7 @@ gitlab_runner_registration_config = {
 }
 ```
 
-For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will lookup the required values via the parameter store. If the value is `null` a new runner will be created.
+For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will lookup the required values via the parameter store. If the value is `null` a new runner will be registered and a new token created/stored.
 
 ``` sh
 # set the following variables, look up the variables in your Terraform config.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 
 ### GitLab runner token configuration
 
-By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS parameter store. See [example](examples/runner-pre-registered/) for more details.
+By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS SSM parameter store. See [example](examples/runner-pre-registered/) for more details.
 
 To register the runner automatically set the variable `gitlab_runner_registration_config["token"]`. This token value can be found in your GitLab project, group, or global settings. For a generic runner you can find the token in the admin section. By default the runner will be locked to the target project, not run untagged. Below is an example of the configuration map.
 
@@ -237,10 +237,10 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
-| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks to *not* be working for this configuration. | map(list(string)) | `<map>` | no |
+| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
 | aws\_region | AWS region. | string | n/a | yes |
-| aws\_zone | AWS availability zone (typically 'a', 'b', or 'c'). | string | `"a"` | no |
+| aws\_zone | AWS availability zone \(typically 'a', 'b', or 'c'\). | string | `"a"` | no |
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | map | `<map>` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | bool | `"true"` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
@@ -249,7 +249,7 @@ terraform destroy
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | cloudwatch\_logging\_retention\_in\_days | Retention for cloudwatch logs. Defaults to unlimited | number | `"0"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
-| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
+| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '\["amazonec2-zone=a"\]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
@@ -267,13 +267,13 @@ terraform destroy
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"12.6.0"` | no |
 | instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
-| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`. | number | `"7"` | no |
+| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable\_kms` is set to `true`. | number | `"7"` | no |
 | kms\_key\_id | KMS key id to encrypted the CloudWatch logs. Ensure CloudWatch has access to the provided KMS key. | string | `""` | no |
-| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
+| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
-| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
@@ -291,21 +291,21 @@ terraform destroy
 | runners\_off\_peak\_idle\_time | Off peak idle time of the runners, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_off\_peak\_periods | Off peak periods of the runners, will be used in the runner config.toml. | string | `""` | no |
 | runners\_off\_peak\_timezone | Off peak idle time zone of the runners, will be used in the runner config.toml. | string | `""` | no |
-| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 (4MB) | number | `"4096"` | no |
-| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after_script. | string | `""` | no |
+| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 \(4MB\) | number | `"4096"` | no |
+| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after\_script. | string | `""` | no |
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | bool | `"true"` | no |
-| runners\_pull\_policy | pull_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
-| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | number | `"1"` | no |
+| runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
+| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab \(default 1\) | number | `"1"` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | bool | `"true"` | no |
 | runners\_root\_size | Runner instance root size in GB. | number | `"16"` | no |
 | runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| runners\_shm\_size | shm_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
+| runners\_shm\_size | shm\_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | bool | `"true"` | no |
 | runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable_schedule is set to true. | map | `<map>` | no |
+| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable\_schedule is set to true. | map | `<map>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_key\_pair | Set this to use existing AWS key pair | string | `""` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | `""` | no |

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -57,7 +57,7 @@ In this scenario *not* docker machine is used but docker to schedule the builds.
 
 Ensure you have Terraform installed the modules is based on Terraform 0.11, see `.terraform-version` for the used version. A handy tool to mange your Terraform version is [tfenv](https://github.com/kamatama41/tfenv).
 
-On macOS it is simple to install `tfenv` using brew.
+On macOS it is simple to install `tfenv` using `brew`.
 
 ``` sh
 brew install tfenv
@@ -71,7 +71,17 @@ tfenv install <version>
 
 ### AWS
 
-Ensure you have setup you AWS credentials. The module requires access to IAM, EC2, CloudWatch, S3 and SSM.
+Ensure you have setup your AWS credentials. The module requires access to IAM, EC2, CloudWatch, S3 and SSM.
+
+### JQ & AWS CLI
+
+In order to be able to destroy the module, you will need to run from a host with both `jq` and `aws` installed and accessible in the environment.
+
+On macOS it is simple to install them using `brew`.
+
+``` sh
+brew install jq awscli
+```
 
 ### Service linked roles
 
@@ -94,7 +104,7 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 
 ### GitLab runner token configuration
 
-By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the parameter store. See [example](examples/runner-pre-registered/) for more details.
+By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS SSM parameter store. See [example](examples/runner-pre-registered/) for more details.
 
 To register the runner automatically set the variable `gitlab_runner_registration_config["token"]`. This token value can be found in your GitLab project, group, or global settings. For a generic runner you can find the token in the admin section. By default the runner will be locked to the target project, not run untagged. Below is an example of the configuration map.
 
@@ -110,7 +120,7 @@ gitlab_runner_registration_config = {
 }
 ```
 
-For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will lookup the required values via the parameter store. If the value is `null` a new runner will be created.
+For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will lookup the required values via the parameter store. If the value is `null` a new runner will be registered and a new token created/stored.
 
 ``` sh
 # set the following variables, look up the variables in your Terraform config.

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -3,10 +3,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
-| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks to *not* be working for this configuration. | map(list(string)) | `<map>` | no |
+| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
 | aws\_region | AWS region. | string | n/a | yes |
-| aws\_zone | AWS availability zone (typically 'a', 'b', or 'c'). | string | `"a"` | no |
+| aws\_zone | AWS availability zone \(typically 'a', 'b', or 'c'\). | string | `"a"` | no |
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | map | `<map>` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | bool | `"true"` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
@@ -15,7 +15,7 @@
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | cloudwatch\_logging\_retention\_in\_days | Retention for cloudwatch logs. Defaults to unlimited | number | `"0"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
-| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
+| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '\["amazonec2-zone=a"\]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
@@ -33,13 +33,13 @@
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"12.6.0"` | no |
 | instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
-| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`. | number | `"7"` | no |
+| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable\_kms` is set to `true`. | number | `"7"` | no |
 | kms\_key\_id | KMS key id to encrypted the CloudWatch logs. Ensure CloudWatch has access to the provided KMS key. | string | `""` | no |
-| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
+| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
-| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
@@ -57,21 +57,21 @@
 | runners\_off\_peak\_idle\_time | Off peak idle time of the runners, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_off\_peak\_periods | Off peak periods of the runners, will be used in the runner config.toml. | string | `""` | no |
 | runners\_off\_peak\_timezone | Off peak idle time zone of the runners, will be used in the runner config.toml. | string | `""` | no |
-| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 (4MB) | number | `"4096"` | no |
-| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after_script. | string | `""` | no |
+| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 \(4MB\) | number | `"4096"` | no |
+| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after\_script. | string | `""` | no |
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | bool | `"true"` | no |
-| runners\_pull\_policy | pull_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
-| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | number | `"1"` | no |
+| runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
+| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab \(default 1\) | number | `"1"` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | bool | `"true"` | no |
 | runners\_root\_size | Runner instance root size in GB. | number | `"16"` | no |
 | runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| runners\_shm\_size | shm_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
+| runners\_shm\_size | shm\_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | bool | `"true"` | no |
 | runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable_schedule is set to true. | map | `<map>` | no |
+| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable\_schedule is set to true. | map | `<map>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_key\_pair | Set this to use existing AWS key pair | string | `""` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | `""` | no |

--- a/bin/remove-runner.sh
+++ b/bin/remove-runner.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+TOKEN=$(aws ssm get-parameters --name $3 --with-decryption --region $1 | jq -r ".Parameters | .[0] | .Value")
+curl -sS --request DELETE "${2}/api/v4/runners" --form "token=${TOKEN}"

--- a/cache/README.md
+++ b/cache/README.md
@@ -43,4 +43,4 @@ module "runner" {
 |------|-------------|
 | arn | The ARN of the created bucket. |
 | bucket | Name of the created bucket. |
-| policy\_arn | Policy for users of the cache (bucket). |
+| policy\_arn | Policy for users of the cache \(bucket\). |

--- a/cache/_docs/TF_MODULE.md
+++ b/cache/_docs/TF_MODULE.md
@@ -16,5 +16,5 @@
 |------|-------------|
 | arn | The ARN of the created bucket. |
 | bucket | Name of the created bucket. |
-| policy\_arn | Policy for users of the cache (bucket). |
+| policy\_arn | Policy for users of the cache \(bucket\). |
 

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,15 @@ resource "aws_ssm_parameter" "runner_registration_token" {
   }
 }
 
+resource "null_resource" "remove_runner" {
+  depends_on = [aws_ssm_parameter.runner_registration_token]
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = "${path.module}/bin/remove-runner.sh ${var.aws_region} ${var.runners_gitlab_url} ${local.secure_parameter_store_runner_token_key}"
+  }
+}
+
 data "template_file" "user_data" {
   template = file("${path.module}/template/user-data.tpl")
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -64,44 +64,51 @@ lockfile=/var/lock/subsys/remove_runner_key
 
 
 start() {
-    touch $lockfile
+    touch \$lockfile
 }
 
 stop() {
     echo -n "Removing Gitlab Runner Token"
     aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="null" && \
         curl --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token"
-    retval=$?
-    [ $retval -eq 0 ] && rm -f $lockfile
-    return $retval
+    retval=\$?
+    [ \$retval -eq 0 ] && rm -f \$lockfile
+    return \$retval
 }
 
-restart() {}
+restart() {
+  :
+}
 
-reload() {}
+reload() {
+  :
+}
 
-status() {}
+status() {
+  :
+}
 
-case "$1" in
+case "\$1" in
     start)
-        $1
+        \$1
         ;;
     stop)
-        $1
+        \$1
         ;;
     restart)
-        $1
+        \$1
         ;;
     status)
-        $1
+        \$1
         ;;
     *)
-        echo "Usage: $0 {start|stop|status|restart}"
+        echo "Usage: \$0 {start|stop|status|restart}"
         exit 2
         ;;
+esac
 REM
 
-# Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
+# Use chkconfig to link into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
 chmod a+x /etc/init.d/remove_gitlab_registration
 chkconfig --add remove_gitlab_registration

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -54,7 +54,7 @@ fi
 sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml
 
 # A small script to remove this runner from being registered with Gitlab. 
-echo "curl --request DELETE --header \"PRIVATE-TOKEN: ${token}\" \"${runners_gitlab_url}/api/v4/runners/6\"" > /etc/init.d/remove_gitlab_registration.sh
+echo "curl --request DELETE --header \"PRIVATE-TOKEN: $token\" \"${runners_gitlab_url}/api/v4/runners/6\"" > /etc/init.d/remove_gitlab_registration.sh
 
 # Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -55,7 +55,7 @@ sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config
 
 # A small script to remove this runner from being registered with Gitlab. 
 echo -e "#!/bin/bash\ncurl --request DELETE \"${runners_gitlab_url}/api/v4/runners\" --form \"token=$token\"" > /etc/init.d/remove_gitlab_registration.sh
-echo "aws ssm delete-parameter --name \"${secure_parameter_store_runner_token_key}\" --region \"${secure_parameter_store_region}\"" >> /etc/init.d/remove_gitlab_registration.sh
+echo "aws ssm put-parameter --overwrite --type SecureString  --name \"${secure_parameter_store_runner_token_key}\" --region \"${secure_parameter_store_region}\" --value=\"null\"" >> /etc/init.d/remove_gitlab_registration.sh
 
 # Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -78,10 +78,11 @@ stop() {
     return \$retval
 }
 
+# Map these to start just to be redunant.
+# We don't want to run Stop outside of shutdown.
 restart() {
   start
 }
-
 reload() {
   start
 }

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -54,7 +54,7 @@ fi
 sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml
 
 # A small script to remove this runner from being registered with Gitlab. 
-echo "curl --request DELETE --header \"PRIVATE-TOKEN: $token\" \"${runners_gitlab_url}/api/v4/runners/6\"" > /etc/init.d/remove_gitlab_registration.sh
+echo -e "#!/bin/bash\ncurl --request DELETE \"${runners_gitlab_url}/api/v4/runners\" --form \"token=$token\"" > /etc/init.d/remove_gitlab_registration.sh
 
 # Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -59,8 +59,8 @@ echo "aws ssm put-parameter --overwrite --type SecureString  --name \"${secure_p
 
 # Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
-ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc0.d/k99remove_runner
-ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc6.d/k99remove_runner
+ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc0.d/K99remove_runner
+ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc6.d/K99remove_runner
 chmod a+x /etc/init.d/remove_gitlab_registration.sh
 
 ${post_install}

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -56,7 +56,7 @@ sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config
 # A small script to remove this runner from being registered with Gitlab. 
 cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration
 #!/bin/bash
-# chkconfig: 35 99 03
+# chkconfig: 1356 99 03
 # description: cleans up gitlab runner key
 # processname: remove_runner_key
 #              /etc/rc.d/init.d/remove_gitlab_registration
@@ -78,11 +78,11 @@ stop() {
 }
 
 restart() {
-  :
+  start
 }
 
 reload() {
-  :
+  start
 }
 
 status() {
@@ -109,10 +109,11 @@ case "\$1" in
 esac
 REM
 
-# Use chkconfig to link into the runlevel 0 (shutdown) and 6 (reboot) directories
+# Use chkconfig to link into the runlevel 0 (shutdown) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
 chmod a+x /etc/init.d/remove_gitlab_registration
 chkconfig --add remove_gitlab_registration
+touch /var/lock/subsys/remove_gitlab_registration
 
 ${post_install}
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -53,6 +53,15 @@ fi
 
 sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml
 
+# A small script to remove this runner from being registered with Gitlab. 
+echo "curl --request DELETE --header \"PRIVATE-TOKEN: ${token}\" \"${runners_gitlab_url}/api/v4/runners/6\"" > /etc/init.d/remove_gitlab_registration.sh
+
+# Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
+# This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
+ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc0.d/k99remove_runner
+ln -s /etc/init.d/remove_gitlab_registration.sh /etc/rc6.d/k99remove_runner
+chmod a+x /etc/init.d/remove_gitlab_registration.sh
+
 ${post_install}
 
 service gitlab-runner restart

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -60,19 +60,20 @@ cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration
 # description: cleans up gitlab runner key
 # processname: remove_runner_key
 #              /etc/rc.d/init.d/remove_gitlab_registration
-lockfile=/var/lock/subsys/remove_runner_key
+lockfile=/var/lock/subsys/remove_gitlab_registration
 
 
 start() {
+    logger "Setting up Runner Removal Lockfile"
     touch \$lockfile
 }
 
 stop() {
-    echo -n "Removing Gitlab Runner Token"
-    aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="null" && \
-        curl --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token"
+    logger "Removing Gitlab Runner Token"
+    aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="null" 2>&1 | logger &
+    curl --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token" 2>&1 | logger &
     retval=\$?
-    [ \$retval -eq 0 ] && rm -f \$lockfile
+    rm -f \$lockfile
     return \$retval
 }
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -55,6 +55,7 @@ sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config
 
 # A small script to remove this runner from being registered with Gitlab. 
 echo -e "#!/bin/bash\ncurl --request DELETE \"${runners_gitlab_url}/api/v4/runners\" --form \"token=$token\"" > /etc/init.d/remove_gitlab_registration.sh
+echo "aws ssm delete-parameter --name \"${secure_parameter_store_runner_token_key}\" --region \"${secure_parameter_store_region}\"" >> /etc/init.d/remove_gitlab_registration.sh
 
 # Symlink the script into the runlevel 0 (shutdown) and 6 (reboot) directories
 # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.


### PR DESCRIPTION
## Description
This is primarily set up to resolve the issues I pointed out in #163. This creates a one-line script that sends a `DELETE` request to the proper Gitlab endpoint to remove this runner from Gitlab. I'm also removing the key from SSM at the same time, since the key is now unable to be used in the future. 

## Migrations required
NO, I don't think?

## Verification
I've been verifying this by pointing my usage of this module to my fork/branch and then trying doing apply/destroys. At this point, it seems to be working as expected, but I'd love to see someone else validate it on their own.

## Documentation
I've added what I help are appropriate comments - let me know if I should add more robust documentation elsewhere, but this doesn't seem to have a place to put it.

## Issues Outstanding

~~Currently, I'm running into problems around the use of SSM caching of the runner Token in the following situation:~~
    1. ~~Token is returned when the Runner is created the first time.~~
    2. ~~Token is put into SSM as a param.~~
    3. ~~I terminate the instance in the ASG from the AWS Console to simulate an instance failure/reboot.~~
    4. ~~The runner api is called with a `DELETE` for that token, removing the runner as expected.~~
    5. ~~A new instance boots, finds the token in SSM and presumably tries to use it like normal to register.~~
    6. ~~Seemingly, Gitlab rejects the token, since it's been removed/deleted, but there's not fallback/retry/reset built into the boot script, so the instance is up and running, but not registered with Gitlab.~~

~~I'm not totally sure how to get around this. We could probably set up some sort of retry logic around registering the Gitlab runner with tokens, where it would fall back and register from scratch if it's rejected with that token?~~

~~I also just don't generally understand the purpose of the SSM caching of something that Gitlab seems to treat as a per-Runner key. Why not just always get a new key for every instance and de-register them as the instance dies?~~

Issues seem to be resolved in my own testing at this point!