### PR TITLE
Change default for gitlab_url to https://gitlab.com

### DIFF
--- a/examples/runner-docker/README.md
+++ b/examples/runner-docker/README.md
@@ -27,7 +27,7 @@ The terraform version is managed using [tfenv](https://github.com/Zordrak/tfenv)
 |------|-------------|:----:|:-----:|:-----:|
 | aws\_region | AWS region. | string | `"eu-west-1"` | no |
 | environment | A name that identifies the environment, will used as prefix and for tagging. | string | `"runners-docker"` | no |
-| gitlab\_url | URL of the gitlab instance to connect to. | string | `"https://www.gitlab.com"` | no |
+| gitlab\_url | URL of the gitlab instance to connect to. | string | `"https://gitlab.com"` | no |
 | private\_ssh\_key\_filename |  | string | `"generated/id_rsa"` | no |
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | registration\_token |  | string | n/a | yes |

--- a/examples/runner-docker/_docs/TF_MODULE.md
+++ b/examples/runner-docker/_docs/TF_MODULE.md
@@ -4,7 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | aws\_region | AWS region. | string | `"eu-west-1"` | no |
 | environment | A name that identifies the environment, will used as prefix and for tagging. | string | `"runners-docker"` | no |
-| gitlab\_url | URL of the gitlab instance to connect to. | string | `"https://www.gitlab.com"` | no |
+| gitlab\_url | URL of the gitlab instance to connect to. | string | `"https://gitlab.com"` | no |
 | private\_ssh\_key\_filename |  | string | `"generated/id_rsa"` | no |
 | public\_ssh\_key\_filename |  | string | `"generated/id_rsa.pub"` | no |
 | registration\_token |  | string | n/a | yes |

--- a/examples/runner-docker/variables.tf
+++ b/examples/runner-docker/variables.tf
@@ -27,7 +27,7 @@ variable "runner_name" {
 variable "gitlab_url" {
   description = "URL of the gitlab instance to connect to."
   type        = string
-  default     = "https://www.gitlab.com"
+  default     = "https://gitlab.com"
 }
 
 variable "registration_token" {


### PR DESCRIPTION
## Description
Docker runners artifact upload fails with error described in:
https://gitlab.com/gitlab-org/gitlab-runner/issues/4083

The default value of the `gitlab_url` variable should be `https://gitlab.com` and not `https://www.gitlab.com`.

See #169

## Migrations required
NO

## Verification
Tested the change using docker-runner using the value `https://gitlab.com` in `runners_gitlab_url`.

## Documentation
updated:
* examples/runner-docker/_docs/TF_MODULE.md
* examples/runner-docker/README.md
