### PR TITLE
Fixed missing double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ module "runner" {
   runners_gitlab_url = "https://gitlab.com"
 
   gitlab_runner_registration_config = {
-    registration_token = "my-token
+    registration_token = "my-token"
     tag_list           = "docker"
     description        = "runner default"
     locked_to_project  = "true"


### PR DESCRIPTION
Fixed missing double quotes in gitlab_runner_registration_config

## Description
Simply a missing closing double-quotes

## Migrations required
NO

## Verification
No need verification.

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
