### PR TITLE
Forcing updates of Instances on Config change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
-| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks to *not* be working for this configuration. | map(list(string)) | `<map>` | no |
+| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
 | aws\_region | AWS region. | string | n/a | yes |
-| aws\_zone | AWS availability zone (typically 'a', 'b', or 'c'). | string | `"a"` | no |
+| aws\_zone | AWS availability zone \(typically 'a', 'b', or 'c'\). | string | `"a"` | no |
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | map | `<map>` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | bool | `"true"` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
@@ -239,12 +239,13 @@ terraform destroy
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | cloudwatch\_logging\_retention\_in\_days | Retention for cloudwatch logs. Defaults to unlimited | number | `"0"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
-| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
+| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '\["amazonec2-zone=a"\]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | bool | `"true"` | no |
 | enable\_eip | Enable the assignment of an EIP to the gitlab runner instance | bool | `"false"` | no |
+| enable\_forced\_updates | Enable automatic redeployment of the Runner ASG when the Launch Configs change. | bool | `"false"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | bool | `"false"` | no |
 | enable\_kms | Let the module manage a KMS key, logs will be encrypted via KMS. Be-aware of the costs of an custom key. | bool | `"false"` | no |
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | bool | `"true"` | no |
@@ -257,13 +258,13 @@ terraform destroy
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"12.6.0"` | no |
 | instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
-| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`. | number | `"7"` | no |
+| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable\_kms` is set to `true`. | number | `"7"` | no |
 | kms\_key\_id | KMS key id to encrypted the CloudWatch logs. Ensure CloudWatch has access to the provided KMS key. | string | `""` | no |
-| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
+| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
-| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
@@ -281,21 +282,21 @@ terraform destroy
 | runners\_off\_peak\_idle\_time | Off peak idle time of the runners, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_off\_peak\_periods | Off peak periods of the runners, will be used in the runner config.toml. | string | `""` | no |
 | runners\_off\_peak\_timezone | Off peak idle time zone of the runners, will be used in the runner config.toml. | string | `""` | no |
-| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 (4MB) | number | `"4096"` | no |
-| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after_script. | string | `""` | no |
+| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 \(4MB\) | number | `"4096"` | no |
+| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after\_script. | string | `""` | no |
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | bool | `"true"` | no |
-| runners\_pull\_policy | pull_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
-| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | number | `"1"` | no |
+| runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
+| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab \(default 1\) | number | `"1"` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | bool | `"true"` | no |
 | runners\_root\_size | Runner instance root size in GB. | number | `"16"` | no |
 | runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| runners\_shm\_size | shm_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
+| runners\_shm\_size | shm\_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | bool | `"true"` | no |
 | runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable_schedule is set to true. | map | `<map>` | no |
+| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable\_schedule is set to true. | map | `<map>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_key\_pair | Set this to use existing AWS key pair | string | `""` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | `""` | no |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -3,10 +3,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
-| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks to *not* be working for this configuration. | map(list(string)) | `<map>` | no |
+| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
 | aws\_region | AWS region. | string | n/a | yes |
-| aws\_zone | AWS availability zone (typically 'a', 'b', or 'c'). | string | `"a"` | no |
+| aws\_zone | AWS availability zone \(typically 'a', 'b', or 'c'\). | string | `"a"` | no |
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | map | `<map>` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | bool | `"true"` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | string | `""` | no |
@@ -15,12 +15,13 @@
 | cache\_shared | Enables cache sharing between runners, false by default. | bool | `"false"` | no |
 | cloudwatch\_logging\_retention\_in\_days | Retention for cloudwatch logs. Defaults to unlimited | number | `"0"` | no |
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | string | `"m5a.large"` | no |
-| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | list(string) | `<list>` | no |
+| docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '\["amazonec2-zone=a"\]' | list(string) | `<list>` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | string | `"0.06"` | no |
 | docker\_machine\_version | Version of docker-machine. | string | `"0.16.2"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | bool | `"true"` | no |
 | enable\_eip | Enable the assignment of an EIP to the gitlab runner instance | bool | `"false"` | no |
+| enable\_forced\_updates | Enable automatic redeployment of the Runner ASG when the Launch Configs change. | bool | `"false"` | no |
 | enable\_gitlab\_runner\_ssh\_access | Enables SSH Access to the gitlab runner instance. | bool | `"false"` | no |
 | enable\_kms | Let the module manage a KMS key, logs will be encrypted via KMS. Be-aware of the costs of an custom key. | bool | `"false"` | no |
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | bool | `"true"` | no |
@@ -33,13 +34,13 @@
 | gitlab\_runner\_version | Version of the GitLab runner. | string | `"12.6.0"` | no |
 | instance\_role\_json | Default runner instance override policy, expected to be in JSON format. | string | `""` | no |
 | instance\_type | Instance type used for the GitLab runner. | string | `"t3.micro"` | no |
-| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`. | number | `"7"` | no |
+| kms\_deletion\_window\_in\_days | Key rotation window, set to 0 for no rotation. Only used when `enable\_kms` is set to `true`. | number | `"7"` | no |
 | kms\_key\_id | KMS key id to encrypted the CloudWatch logs. Ensure CloudWatch has access to the provided KMS key. | string | `""` | no |
-| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
+| overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
-| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
@@ -57,21 +58,21 @@
 | runners\_off\_peak\_idle\_time | Off peak idle time of the runners, will be used in the runner config.toml. | number | `"0"` | no |
 | runners\_off\_peak\_periods | Off peak periods of the runners, will be used in the runner config.toml. | string | `""` | no |
 | runners\_off\_peak\_timezone | Off peak idle time zone of the runners, will be used in the runner config.toml. | string | `""` | no |
-| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 (4MB) | number | `"4096"` | no |
-| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after_script. | string | `""` | no |
+| runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 \(4MB\) | number | `"4096"` | no |
+| runners\_post\_build\_script | Commands to be executed on the Runner just after executing the build, but before executing after\_script. | string | `""` | no |
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | string | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | string | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | bool | `"true"` | no |
-| runners\_pull\_policy | pull_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
-| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | number | `"1"` | no |
+| runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | string | `"always"` | no |
+| runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab \(default 1\) | number | `"1"` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | bool | `"true"` | no |
 | runners\_root\_size | Runner instance root size in GB. | number | `"16"` | no |
 | runners\_services\_volumes\_tmpfs | Mount temporary file systems to service containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| runners\_shm\_size | shm_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
+| runners\_shm\_size | shm\_size for the runners, will be used in the runner config.toml | number | `"0"` | no |
 | runners\_token | Token for the runner, will be used in the runner config.toml. | string | `"__REPLACED_BY_USER_DATA__"` | no |
 | runners\_use\_private\_address | Restrict runners to the use of a private IP address | bool | `"true"` | no |
 | runners\_volumes\_tmpfs | Mount temporary file systems to the main containers. Must consist of pairs of strings e.g. "/var/lib/mysql" = "rw,noexec", see example | list | `<list>` | no |
-| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable_schedule is set to true. | map | `<map>` | no |
+| schedule\_config | Map containing the configuration of the ASG scale-in and scale-up for the runner instance. Will only be used if enable\_schedule is set to true. | map | `<map>` | no |
 | secure\_parameter\_store\_runner\_token\_key | The key name used store the Gitlab runner token in Secure Parameter Store | string | `"runner-token"` | no |
 | ssh\_key\_pair | Set this to use existing AWS key pair | string | `""` | no |
 | ssh\_public\_key | Public SSH key used for the GitLab runner EC2 instance. | string | `""` | no |

--- a/cache/README.md
+++ b/cache/README.md
@@ -43,4 +43,4 @@ module "runner" {
 |------|-------------|
 | arn | The ARN of the created bucket. |
 | bucket | Name of the created bucket. |
-| policy\_arn | Policy for users of the cache (bucket). |
+| policy\_arn | Policy for users of the cache \(bucket\). |

--- a/cache/_docs/TF_MODULE.md
+++ b/cache/_docs/TF_MODULE.md
@@ -16,5 +16,5 @@
 |------|-------------|
 | arn | The ARN of the created bucket. |
 | bucket | Name of the created bucket. |
-| policy\_arn | Policy for users of the cache (bucket). |
+| policy\_arn | Policy for users of the cache \(bucket\). |
 

--- a/main.tf
+++ b/main.tf
@@ -256,9 +256,8 @@ data "aws_ami" "docker-machine" {
 }
 
 resource "aws_autoscaling_group" "gitlab_runner_instance" {
-  name                = "${var.environment}-as-group"
-  vpc_zone_identifier = var.subnet_ids_gitlab_runner
-
+  name                      = "${aws_launch_configuration.gitlab_runner_instance.name}-asg"
+  vpc_zone_identifier       = var.subnet_ids_gitlab_runner
   min_size                  = "1"
   max_size                  = "1"
   desired_capacity          = "1"
@@ -320,6 +319,7 @@ locals {
 }
 
 resource "aws_launch_configuration" "gitlab_runner_instance" {
+  name_prefix          = var.runners_name
   security_groups      = [aws_security_group.runner.id]
   key_name             = local.key_pair_name
   image_id             = data.aws_ami.runner.id

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ data "aws_ami" "docker-machine" {
 }
 
 resource "aws_autoscaling_group" "gitlab_runner_instance" {
-  name                      = var.enable_forced_updates ? "${var.environment}-as-group" :"${aws_launch_configuration.gitlab_runner_instance.name}-asg"
+  name                      = var.enable_forced_updates ? "${var.environment}-as-group" : "${aws_launch_configuration.gitlab_runner_instance.name}-asg"
   vpc_zone_identifier       = var.subnet_ids_gitlab_runner
   min_size                  = "1"
   max_size                  = "1"

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ data "aws_ami" "docker-machine" {
 }
 
 resource "aws_autoscaling_group" "gitlab_runner_instance" {
-  name                      = "${aws_launch_configuration.gitlab_runner_instance.name}-asg"
+  name                      = var.enable_forced_updates ? "${var.environment}-as-group" :"${aws_launch_configuration.gitlab_runner_instance.name}-asg"
   vpc_zone_identifier       = var.subnet_ids_gitlab_runner
   min_size                  = "1"
   max_size                  = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -496,3 +496,9 @@ variable "enable_eip" {
   default     = false
   type        = bool
 }
+
+variable "enable_forced_updates" {
+  description = "Enable automatic redeployment of the Runner ASG when the Launch Configs change."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
## Description
Currently, it's possible to `terraform apply` an update to a number of aspects of the Runner, but not see them actually reflected in the running resources because of how AWS works. For example, if I need to change the Runner registration token, you can apply those changes, but the actual Runner resources won't update on their own to pick up that change.

This is due to the fact that in both AWS and Terraform, EC2 Launch Configurations are a separate resource from the EC2 Autoscaling groups. Many/most changes to how the Runners are configured are set as part of the Launch Config, and while Terraform will dutifully create a new Launch Config and update the ASG to use it, the ASG will only apply the new config to _new_ instances, and will not push the update to any currently-running instances in the Group.

There's a number of possible ways to get around this: 

 1. If this was Cloudformation, we could use a built-in lifecycle management tool it has to tell it to trigger a rolling update of all the instances in the ASG. This feature evidently isn't something Terraform can use naturally however, so the only way to use it would be to have Terraform make a Cloudformation resource that created the Launch Config and ASG.
 2. We could make a null resource and trigger it so that when a new Launch Config is made, it goes and Terminates the existing instance in the ASG using the AWS CLI, causing a new one to be created using the new config.
 3. We could link the ASG and Launch Config by name in Terraform so that Terraform would be forced to make a brand new ASG every time we make a new Launch Config, and the new ASG would use the new configs.

Option #1 would require some fairly major adjustment to the project, and would involve doing some templates-inside-templates patterns that I don't really like. Option #2 seems viable, but making sure it's timed correctly seems complicated, and in general I find using custom scripts to do something like this a bit awkward. Option #3 is a bit of a hack of how Terraform works, but in this specific case, happens to directly work with what we need it to do, and has the advantage that it will show up in `plan` output.

Normally, you wouldn't want to do Option 3 because you'd lose any scaling state for the ASG, which could be disastrous if you're relying on Autoscaling to handle load. Since, in this project, the ASG is generally going to only be at 0 or 1 though, we should be mostly safe.

## Migrations required
NO - this should migrate itself cleanly from old versions. The only change to the steady state is in the new names for the resources.

## Verification
Working on verification now - in general, this should be fairly straightforward though, since it's only an adjustment to how Terraform resolves the dependency graph.

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`
