### PR TITLE
Improving Spot Cancelation script.

### DIFF
--- a/ci/bin/cancel-spot-instances.sh
+++ b/ci/bin/cancel-spot-instances.sh
@@ -1,6 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+hash jq aws &>/dev/null || { echo >&2 "I require jq and AWS CLI but one or both is not installed.  Aborting."; exit 1; }
 
 SPOT_REQUESTS=$(aws ec2 describe-spot-instance-requests --filters "Name=state,Values=active,open" | jq -r '[ .SpotInstanceRequests[] | select( .LaunchSpecification.IamInstanceProfile.Name | contains("'$1'")) ]')
 
-echo $SPOT_REQUESTS | jq -r '.[].InstanceId' | xargs aws ec2 terminate-instances --instance-ids
-echo $SPOT_REQUESTS | jq -r '.[].SpotInstanceRequestId' | xargs aws ec2 cancel-spot-instance-requests --spot-instance-request-ids
+# It's possible there's no spot requests to cancel, so be safe.
+if ["$SPOT_REQUESTS" != "[]"]
+    echo $SPOT_REQUESTS | jq -r '.[].InstanceId' | xargs aws ec2 terminate-instances --instance-ids
+    echo $SPOT_REQUESTS | jq -r '.[].SpotInstanceRequestId' | xargs aws ec2 cancel-spot-instance-requests --spot-instance-request-ids
+else
+    # If there's no instances to kill, just log out that and return happy.
+    echo "Found no spot instances to kill or requests to cancel."
+    exit 0
+fi


### PR DESCRIPTION
## Description
While I was working with automating the creation and destruction of Gitlab runners, I noticed a couple issues with the `cancel-spot-instances.sh` script. The first was that we were assuming that `bash` would be installed on the system, in addition to `jq` and `aws`, which isn't true by default in Alpine Linux and other Busybox-based systems where people tend to run CI tasks. Second, if you apply and then immediately delete a set of runners, they won't have any Spot instances or requests to tear down, which causes the script to fail, even though it had nothing to do and should just exit gracefully.

I'm open to removing the check for `aws` and `jq` if we don't want that here. I just added it since the script will fail if either of them is absent, so that line will instead provide a helpful message instead of complaining about a missing package.

## Migrations required
I don't believe anything will be required - this should just add robustness to the deletion process.

## Verification
I've been running with this script off of a wrapper module for this module that my team is using for a bit now without issue, otherwise, you should just be able to `apply` and then quickly `destroy` a deployment of this module to test.

