### PR TITLE
Added agent- and runner-only tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ terraform destroy
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
 | subnet\_ids\_gitlab\_runner | Subnet used for hosting the GitLab runner. | list(string) | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | map(string) | `<map>` | no |
+| agent_tags | Map of tags that will be added to agent EC2 instances. | map(string) | `<map>` | no |
+| runner_tags | Map of tags that will be added to runner EC2 instances. | map(string) | `<map>` | no |
 | userdata\_post\_install | User-data script snippet to insert after GitLab runner install | string | `""` | no |
 | userdata\_pre\_install | User-data script snippet to insert before GitLab runner install | string | `""` | no |
 | vpc\_id | The target VPC for the docker-machine and runner instances. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -209,10 +209,10 @@ data "template_file" "runners" {
     docker_machine_options      = length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string
     runners_name                = var.runners_name
     runners_tags = var.overrides["name_docker_machine_runners"] == "" ? format(
-      "%s,%s,Name,%s-docker-machine",
+      "Name,%s-docker-machine,%s,%s",
+      var.environment,
       local.tags_string,
       local.runner_tags_string,
-      var.environment,
       ) : format(
       "%s,%s,Name,%s",
       local.tags_string,

--- a/main.tf
+++ b/main.tf
@@ -209,12 +209,14 @@ data "template_file" "runners" {
     docker_machine_options      = length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string
     runners_name                = var.runners_name
     runners_tags = var.overrides["name_docker_machine_runners"] == "" ? format(
-      "%s,Name,%s-docker-machine",
+      "%s,%s,Name,%s-docker-machine",
       local.tags_string,
+      local.runner_tags_string,
       var.environment,
       ) : format(
-      "%s,Name,%s",
+      "%s,%s,Name,%s",
       local.tags_string,
+      local.runner_tags_string,
       var.overrides["name_docker_machine_runners"],
     )
     runners_token                     = var.runners_token
@@ -282,6 +284,11 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
         "propagate_at_launch" = true
       },
     ],
+    [for key in keys(var.agent_tags) : {
+      "key"                 = key,
+      "value"               = lookup(var.agent_tags, key),
+      "propagate_at_launch" = true
+    }]
   )
 
 }

--- a/tags.tf
+++ b/tags.tf
@@ -12,6 +12,10 @@ locals {
   tags_string = join(",", flatten([
     for key in keys(local.tags) : [key, lookup(local.tags, key)]
   ]))
+
+  runner_tags_string = join(",", flatten([
+    for key in keys(var.runner_tags) : [key, lookup(var.runner_tags, key)]
+  ]))
 }
 
 data "null_data_source" "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -321,6 +321,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "agent_tags" {
+  description = "Map of tags that will be added to agent EC2 instances."
+  type        = map(string)
+  default     = {}
+}
+
+variable "runner_tags" {
+  description = "Map of tags that will be added to runner EC2 instances."
+  type        = map(string)
+  default     = {}
+}
+
 variable "allow_iam_service_linked_role_creation" {
   description = "Boolean used to control attaching the policy to a runner instance to create service linked roles."
   type        = bool


### PR DESCRIPTION
### Description
<!--A few sentences describing the overall goals of the pull request's commits.-->
Solves #175. We need to apply tags only to the EC2 resources for an application that manages resources by tag.

### Migrations required
<!--YES | NO - If yes please describe the migration.-->
NO

### Verification
<!--Please mention the examples you have verified.-->

### Documentation
<!--Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`-->
Readme updated