### PR TITLE
Add inputs for EBS-optimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ terraform destroy
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| agent\_tags | Map of tags that will be added to agent EC2 instances. | map(string) | `<map>` | no |
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
 | ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
@@ -273,10 +274,13 @@ terraform destroy
 | overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
+| runner\_instance\_ebs\_optimized | Enable the GitLab runner instance to be EBS-optimized. | bool | `"true"` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
 | runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_tags | Map of tags that will be added to runner EC2 instances. | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
+| runners\_ebs\_optimized | Enable runners to be EBS-optimized. | bool | `"true"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
 | runners\_executor | The executor to use. Currently supports `docker+machine` or `docker`. | string | `"docker+machine"` | no |
 | runners\_gitlab\_url | URL of the GitLab instance to connect to. | string | n/a | yes |
@@ -313,8 +317,6 @@ terraform destroy
 | subnet\_id\_runners | List of subnets used for hosting the gitlab-runners. | string | n/a | yes |
 | subnet\_ids\_gitlab\_runner | Subnet used for hosting the GitLab runner. | list(string) | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | map(string) | `<map>` | no |
-| agent_tags | Map of tags that will be added to agent EC2 instances. | map(string) | `<map>` | no |
-| runner_tags | Map of tags that will be added to runner EC2 instances. | map(string) | `<map>` | no |
 | userdata\_post\_install | User-data script snippet to insert after GitLab runner install | string | `""` | no |
 | userdata\_pre\_install | User-data script snippet to insert before GitLab runner install | string | `""` | no |
 | vpc\_id | The target VPC for the docker-machine and runner instances. | string | n/a | yes |

--- a/_docs/TF_MODULE.md
+++ b/_docs/TF_MODULE.md
@@ -2,6 +2,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| agent\_tags | Map of tags that will be added to agent EC2 instances. | map(string) | `<map>` | no |
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
 | ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
@@ -39,10 +40,13 @@
 | overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name\_sg` overwrite the `Name` tag for all security groups created by this module. `name\_runner\_agent\_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name\_docker\_machine\_runners` ovverrid the `Name` tag spot instances created by the runner agent. | map(string) | `<map>` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | map(list(string)) | `<map>` | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | list(string) | `<list>` | no |
+| runner\_instance\_ebs\_optimized | Enable the GitLab runner instance to be EBS-optimized. | bool | `"true"` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | string | `""` | no |
 | runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete\_on\_termination`, `volume\_type`, `volume\_size`, `encrypted`, `iops` | map(string) | `<map>` | no |
+| runner\_tags | Map of tags that will be added to runner EC2 instances. | map(string) | `<map>` | no |
 | runners\_additional\_volumes | Additional volumes that will be used in the runner config.toml, e.g Docker socket | list | `<list>` | no |
 | runners\_concurrent | Concurrent value for the runners, will be used in the runner config.toml. | number | `"10"` | no |
+| runners\_ebs\_optimized | Enable runners to be EBS-optimized. | bool | `"true"` | no |
 | runners\_environment\_vars | Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml | list(string) | `<list>` | no |
 | runners\_executor | The executor to use. Currently supports `docker+machine` or `docker`. | string | `"docker+machine"` | no |
 | runners\_gitlab\_url | URL of the GitLab instance to connect to. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -204,6 +204,7 @@ data "template_file" "runners" {
     runners_ami                 = data.aws_ami.docker-machine.id
     runners_security_group_name = aws_security_group.docker_machine.name
     runners_monitoring          = var.runners_monitoring
+    runners_ebs_optimized       = var.runners_ebs_optimized
     runners_instance_profile    = aws_iam_instance_profile.docker_machine.name
     runners_additional_volumes  = local.runners_additional_volumes
     docker_machine_options      = length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string
@@ -341,6 +342,7 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
   image_id             = data.aws_ami.runner.id
   user_data            = data.template_file.user_data.rendered
   instance_type        = var.instance_type
+  ebs_optimized        = var.runner_instance_ebs_optimized
   spot_price           = var.runner_instance_spot_price
   iam_instance_profile = aws_iam_instance_profile.instance.name
   dynamic "root_block_device" {

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -51,6 +51,7 @@ check_interval = 0
       "amazonec2-spot-price=${runners_spot_price_bid}",
       "amazonec2-security-group=${runners_security_group_name}",
       "amazonec2-tags=${runners_tags}",
+      "amazonec2-use-ebs-optimized-instance=${runners_ebs_optimized}",
       "amazonec2-monitoring=${runners_monitoring}",
       "amazonec2-iam-instance-profile=%{ if runners_iam_instance_profile_name != "" }${runners_iam_instance_profile_name}%{ else }${runners_instance_profile}%{ endif ~}",
       "amazonec2-root-size=${runners_root_size}",

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "instance_type" {
   default     = "t3.micro"
 }
 
+variable "runner_instance_ebs_optimized" {
+  description = "Enable the GitLab runner instance to be EBS-optimized."
+  type        = bool
+  default     = true
+}
+
 variable "runner_instance_spot_price" {
   description = "By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS."
   type        = string
@@ -157,6 +163,12 @@ variable "runners_monitoring" {
   description = "Enable detailed cloudwatch monitoring for spot instances."
   type        = bool
   default     = false
+}
+
+variable "runners_ebs_optimized" {
+  description = "Enable runners to be EBS-optimized."
+  type        = bool
+  default     = true
 }
 
 variable "runners_off_peak_timezone" {


### PR DESCRIPTION
## Description
Without specifying an EBS-optimized, AWS defaults to `false`.  This adds an EBS-optimized configuration option to both the runner instance and runners. Defaults them both to `true` (both the default GitLab runner instance type, `t3.micro`, and the default docker machine runners instance type, `m5a.large`, use EBS-optimized by default anyways, even though the instances are currently set to disabled).

## Migrations required
NO

## Verification
default example