### PR TITLE
Bump gitlab runner version to 12.7.1 from 12.6.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -300,7 +300,7 @@ variable "cache_shared" {
 variable "gitlab_runner_version" {
   description = "Version of the GitLab runner."
   type        = string
-  default     = "12.6.0"
+  default     = "12.7.1"
 }
 
 variable "enable_gitlab_runner_ssh_access" {


### PR DESCRIPTION
## Description
Bump runner version from `12.6.0` to `12.7.1`
See [GitLab ChangeLog](https://gitlab.com/gitlab-org/gitlab-runner/blob/master/CHANGELOG.md)

## Migrations required
NO

## Verification
Nothing

## Documentation
Nothing