### PR TITLE
Support Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ gitlab_url   = "GITLAB_URL"
 runner_token = "RUNNER_TOKEN"
 ```
 
-The base image used to host the GitLab Runner agent is the latest available Amazon Linux HVM EBS AMI. In previous versions of this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest AMI. Setting the filter to `amzn-ami-hvm-2018.03.0.20180622-x86_64-ebs` will allow you to version lock the target AMI.
+The base image used to host the GitLab Runner agent is the latest available Amazon Linux 2 HVM EBS AMI. In previous versions of this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest AMI. Setting the filter to `amzn2-ami-hvm-2.0.20200207.1-x86_64-ebs` will allow you to version lock the target AMI.
 
 ### Usage module
 
@@ -237,7 +237,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | bool | `"true"` | no |
-| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86\_64-ebs` looks to \*not\* be working for this configuration. | map(list(string)) | `<map>` | no |
+| ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Must resolve to an Amazon Linux 1 or 2 image. | map(list(string)) | `<map>` | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | list(string) | `<list>` | no |
 | aws\_region | AWS region. | string | n/a | yes |
 | aws\_zone | AWS availability zone \(typically 'a', 'b', or 'c'\). | string | `"a"` | no |

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -163,7 +163,7 @@ gitlab_url   = "GITLAB_URL"
 runner_token = "RUNNER_TOKEN"
 ```
 
-The base image used to host the GitLab Runner agent is the latest available Amazon Linux HVM EBS AMI. In previous versions of this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest AMI. Setting the filter to `amzn-ami-hvm-2018.03.0.20180622-x86_64-ebs` will allow you to version lock the target AMI.
+The base image used to host the GitLab Runner agent is the latest available Amazon Linux 2 HVM EBS AMI. In previous versions of this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest AMI. Setting the filter to `amzn2-ami-hvm-2.0.20200207.1-x86_64-ebs` will allow you to version lock the target AMI.
 
 ### Usage module
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -9,9 +9,18 @@ ${pre_install}
 
 if [[ `echo ${runners_executor}` == "docker" ]]
 then
-  yum install docker -y
-  usermod -a -G docker ec2-user
-  service docker start
+  echo 'installing docker'
+  if grep -q ':2$' /etc/system-release-cpe  ; then
+    # AWS Linux 2 provides docker via extras only and uses systemd (https://aws.amazon.com/amazon-linux-2/release-notes/)
+    amazon-linux-extras install docker
+    usermod -a -G docker ec2-user
+    systemctl enable docker
+    systemctl start docker
+  else
+    yum install docker -y
+    usermod -a -G docker ec2-user
+    service docker start
+  fi
 fi
 
 curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash

--- a/template/logging.tpl
+++ b/template/logging.tpl
@@ -40,6 +40,11 @@ sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
 instanceId=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .instanceId)
 sed -i -e "s/{instanceId}/$instanceId/g" /etc/awslogs/awslogs.conf
 
-
-service awslogs start
-chkconfig awslogs on
+if grep -q ':2$' /etc/system-release-cpe  ; then
+  # AWS Linux 2 renamed the awslogs service to awslogsd and uses systemd
+  systemctl enable awslogsd
+  systemctl start awslogsd
+else
+  service awslogs start
+  chkconfig awslogs on
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -358,11 +358,11 @@ variable "docker_machine_role_json" {
 }
 
 variable "ami_filter" {
-  description = "List of maps used to create the AMI filter for the Gitlab runner agent AMI. Currently Amazon Linux 2 `amzn2-ami-hvm-2.0.????????-x86_64-ebs` looks to *not* be working for this configuration."
+  description = "List of maps used to create the AMI filter for the Gitlab runner agent AMI. Must resolve to an Amazon Linux 1 or 2 image."
   type        = map(list(string))
 
   default = {
-    name = ["amzn-ami-hvm-2018.03*-x86_64-ebs"]
+    name = ["amzn2-ami-hvm-2.*-x86_64-ebs"]
   }
 }
 


### PR DESCRIPTION
## Description
This PR addresses #177. It changes the user data scripts such that they test whether the distribution is Amazon Linux 2 and, if so:

- install docker from the "extras" bundles;
- use systemd to start docker and awslogsd;

## Migrations required
NO

## Verification
Successully deployed GitLab runner and end executed a job using `ami_filter = { name = ["amzn2-ami-hvm-2.0.*-x86_64-ebs"] }`.

## Documentation
I updated the README in `_docs/README.md` and manually updated the README.md in the root  folder. 

The script `ci/bin/autodocs.sh` failed for me with error messages from terraform-docs like: `Failed to read module directory: Module directory /tmp/terraform-docs.YY7w3Rt7Up does not exist or cannot be read.`
