### PR TITLE
Complete docker example with ssh keys usage

### DIFF
--- a/examples/runner-docker/README.md
+++ b/examples/runner-docker/README.md
@@ -10,6 +10,7 @@ This examples shows:
   - Usages of runner of peak time mode configuration.
   - Registration via GitLab token.
   - Auto scaling using `docker+machine` executor. ➜ tmp cat terraform-aws-gitlab-runner/examples/runner-docker/\_docs/README.md
+  - Usage of SSH keys
 
 # Example - Runner - Docker runner
 

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -25,6 +25,8 @@ module "runner" {
   aws_region  = var.aws_region
   environment = var.environment
 
+  ssh_public_key = local_file.public_ssh_key.content
+
   runners_use_private_address = false
   enable_eip                  = true
 


### PR DESCRIPTION
## Description
In runner-docker example, there is a ssh keys generation but these keys are not used in runner module. We can't connect to ec2 instance.

## Migrations required
NO

## Verification
runner-docker example
