### PR TITLE
Parametrize the AWS ARN for policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ terraform destroy
 | allow\_iam\_service\_linked\_role\_creation | Boolean used to control attaching the policy to a runner instance to create service linked roles. | `bool` | `true` | no |
 | ami\_filter | List of maps used to create the AMI filter for the Gitlab runner agent AMI. Must resolve to an Amazon Linux 1 or 2 image. | `map(list(string))` | <pre>{<br>  "name": [<br>    "amzn2-ami-hvm-2.*-x86_64-ebs"<br>  ]<br>}</pre> | no |
 | ami\_owners | The list of owners used to select the AMI of Gitlab runner agent instances. | `list(string)` | <pre>[<br>  "amazon"<br>]</pre> | no |
+| arn\_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions (e.g. `arn:aws-us-gov`/`arn:aws-cn`). | string | <pre>arn:aws</pre> | no |
 | aws\_region | AWS region. | `string` | n/a | yes |
 | aws\_zone | AWS availability zone (typically 'a', 'b', or 'c'). | `string` | `"a"` | no |
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | `map` | <pre>{<br>  "bucket": "",<br>  "create": true,<br>  "policy": ""<br>}</pre> | no |

--- a/cache/main.tf
+++ b/cache/main.tf
@@ -61,7 +61,7 @@ resource "aws_iam_policy" "docker_machine_cache" {
 
   policy = templatefile("${path.module}/policies/cache.json",
     {
-      s3_cache_arn = var.create_cache_bucket == false || length(aws_s3_bucket.build_cache) == 0 ? "arn:aws:s3:::fake_bucket_doesnt_exist" : aws_s3_bucket.build_cache[0].arn
+      s3_cache_arn = var.create_cache_bucket == false || length(aws_s3_bucket.build_cache) == 0 ? "${var.arn_format}:s3:::fake_bucket_doesnt_exist" : aws_s3_bucket.build_cache[0].arn
     }
   )
 }

--- a/cache/variables.tf
+++ b/cache/variables.tf
@@ -38,3 +38,9 @@ variable "create_cache_bucket" {
   type        = bool
   default     = true
 }
+
+variable "arn_format" {
+  type        = string
+  default     = "arn:aws"
+  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions."
+}

--- a/kms.tf
+++ b/kms.tf
@@ -7,6 +7,7 @@ resource "aws_kms_key" "default" {
   tags                    = local.tags
   policy = templatefile("${path.module}/policies/kms-policy.json",
     {
+      arn_format = var.arn_format
       aws_region = var.aws_region
       account_id = data.aws_caller_identity.current.account_id
     }

--- a/logging.tf
+++ b/logging.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role_policy" "instance" {
   count  = var.enable_cloudwatch_logging ? 1 : 0
   name   = "${var.environment}-instance-role"
   role   = aws_iam_role.instance.name
-  policy = templatefile("${path.module}/policies/instance-logging-policy.json", {})
+  policy = templatefile("${path.module}/policies/instance-logging-policy.json", { arn_format = var.arn_format })
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -400,7 +400,7 @@ resource "aws_iam_instance_profile" "instance" {
 resource "aws_iam_role" "instance" {
   name                 = "${var.environment}-instance-role"
   assume_role_policy   = length(var.instance_role_json) > 0 ? var.instance_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
-  permissions_boundary = var.permissions_boundary == "" ? null : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
+  permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
 }
 
 ################################################################################
@@ -443,7 +443,7 @@ resource "aws_iam_role_policy_attachment" "instance_session_manager_aws_managed"
   count = var.enable_runner_ssm_access ? 1 : 0
 
   role       = aws_iam_role.instance.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 
@@ -462,7 +462,7 @@ resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
 resource "aws_iam_role" "docker_machine" {
   name                 = "${var.environment}-docker-machine-role"
   assume_role_policy   = length(var.docker_machine_role_json) > 0 ? var.docker_machine_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
-  permissions_boundary = var.permissions_boundary == "" ? null : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
+  permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
 }
 
 resource "aws_iam_instance_profile" "docker_machine" {
@@ -480,7 +480,7 @@ resource "aws_iam_policy" "service_linked_role" {
   path        = "/"
   description = "Policy for creation of service linked roles."
 
-  policy = templatefile("${path.module}/policies/service-linked-role-create-policy.json", {})
+  policy = templatefile("${path.module}/policies/service-linked-role-create-policy.json", { arn_format = var.arn_format })
 }
 
 resource "aws_iam_role_policy_attachment" "service_linked_role" {
@@ -504,7 +504,7 @@ resource "aws_iam_policy" "ssm" {
   path        = "/"
   description = "Policy for runner token param access via SSM"
 
-  policy = templatefile("${path.module}/policies/instance-secure-parameter-role-policy.json", {})
+  policy = templatefile("${path.module}/policies/instance-secure-parameter-role-policy.json", { arn_format = var.arn_format })
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {

--- a/policies/instance-logging-policy.json
+++ b/policies/instance-logging-policy.json
@@ -11,7 +11,7 @@
         "logs:DescribeLogStreams"
       ],
       "Resource": [
-        "arn:aws:logs:*:*:*"
+        "${arn_format}:logs:*:*:*"
       ]
     }
   ]

--- a/policies/instance-secure-parameter-role-policy.json
+++ b/policies/instance-secure-parameter-role-policy.json
@@ -13,7 +13,7 @@
             "Action": [
                 "ssm:GetParameters"
             ],
-            "Resource": "arn:aws:ssm:*"
+            "Resource": "${arn_format}:ssm:*"
         }
     ]
 }

--- a/policies/kms-policy.json
+++ b/policies/kms-policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${account_id}:root"
+          "${arn_format}:iam::${account_id}:root"
         ]
       },
       "Action": "kms:*",

--- a/policies/service-linked-role-create-policy.json
+++ b/policies/service-linked-role-create-policy.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": "iam:CreateServiceLinkedRole",
-      "Resource": "arn:aws:iam::*:role/aws-service-role/*"
+      "Resource": "${arn_format}:iam::*:role/aws-service-role/*"
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "aws_zone" {
   default     = "a"
 }
 
+variable "arn_format" {
+  type        = string
+  default     = "arn:aws"
+  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions."
+}
+
 variable "environment" {
   description = "A name that identifies the environment, used as prefix and for tagging."
   type        = string


### PR DESCRIPTION
## Description
This change allows a user to override the AWS ARN (which to defaults to
the most common use case of "arn:aws") in order to allow one to use this
module in the AWS GovCloud/China regions. This can be done by setting
the value of the arn_format variable to "arn:aws-us-gov"/"arn:aws-cn"
respectively.

This should address the policy changes necessary for this previously opened PR here:
https://github.com/npalm/terraform-aws-gitlab-runner/pull/110

## Migrations required
NO

## Verification
I have successfully used my fork to deploy within GovCloud.

## Documentation
This new variable has been documented in README.md
