### PR TITLE
Add SSMManagedInstanceCore policy to the docker machine role.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ terraform destroy
 | enable\_manage\_gitlab\_token | Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`. | `bool` | `true` | no |
 | enable\_ping | Allow ICMP Ping to the ec2 instances. | `bool` | `false` | no |
 | enable\_runner\_ssm\_access | Add IAM policies to the runner agent instance to connect via the Session Manager. | `bool` | `false` | no |
+| enable\_docker\_machine\_ssm\_access | Add IAM policies to the docker-machine instances to connect via the Session Manager. | `bool` | `false` | no |
 | enable\_runner\_user\_data\_trace\_log | Enable bash xtrace for the user data script that creates the EC2 instance for the runner agent. Be aware this could log sensitive data such as you GitLab runner token. | `bool` | `false` | no |
 | enable\_schedule | Flag used to enable/disable auto scaling group schedule for the runner instance. | `bool` | `false` | no |
 | environment | A name that identifies the environment, used as prefix and for tagging. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -331,6 +331,13 @@ resource "aws_iam_instance_profile" "docker_machine" {
   role = aws_iam_role.docker_machine.name
 }
 
+resource "aws_iam_role_policy_attachment" "docker_machine_session_manager_aws_managed" {
+  count = var.enable_docker_machine_ssm_access ? 1 : 0
+
+  role       = aws_iam_role.docker_machine.name
+  policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 ################################################################################
 ### Service linked policy, optional
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -503,6 +503,12 @@ variable "enable_runner_ssm_access" {
   default     = false
 }
 
+variable "enable_docker_machine_ssm_access" {
+  description = "Add IAM policies to the docker-machine instances to connect via the Session Manager."
+  type        = bool
+  default     = false
+}
+
 variable "runners_volumes_tmpfs" {
   type = list(object({
     volume  = string


### PR DESCRIPTION
## Description
This change allows us to enable SSM on the docker-machine instances similar to how we can enable it for the runner agent using variables.

## Migrations required
NO

## Verification
We have successfully used our fork to deploy and connect to the docker-machines through SSM.

## Documentation
This new variable has been documented in README.md.
