### PR TITLE
Random suffix to s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ module "runner" {
     tag_list           = "docker"
     description        = "runner default"
     locked_to_project  = "true"
-    run_untagged       = "false"
+     | `bool` | `false` | no |run_untagged       = "false"
     maximum_timeout    = "3600"
   }
 
@@ -276,6 +276,7 @@ terraform destroy
 | cache\_bucket | Configuration to control the creation of the cache bucket. By default the bucket will be created and used as shared cache. To use the same cache across multiple runners disable the creation of the cache and provide a policy and bucket name. See the public runner example for more details. | `map` | <pre>{<br>  "bucket": "",<br>  "create": true,<br>  "policy": ""<br>}</pre> | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | `bool` | `true` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | `string` | `""` | no |
+| cache\_bucket\_set\_random\_suffix | Boolean used to append a random string to the bucket name | `bool` | `false` | no |
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | `bool` | `false` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | `number` | `1` | no |
 | cache\_shared | Enables cache sharing between runners, false by default. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ module "runner" {
     tag_list           = "docker"
     description        = "runner default"
     locked_to_project  = "true"
-     | `bool` | `false` | no |run_untagged       = "false"
+    run_untagged       = "false"
     maximum_timeout    = "3600"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -243,6 +243,7 @@ module "cache" {
   create_cache_bucket                  = var.cache_bucket["create"]
   cache_bucket_prefix                  = var.cache_bucket_prefix
   cache_bucket_name_include_account_id = var.cache_bucket_name_include_account_id
+	cache_bucket_set_random_suffix       = var.cache_bucket_set_random_suffix
   cache_bucket_versioning              = var.cache_bucket_versioning
   cache_expiration_days                = var.cache_expiration_days
 }

--- a/main.tf
+++ b/main.tf
@@ -243,7 +243,7 @@ module "cache" {
   create_cache_bucket                  = var.cache_bucket["create"]
   cache_bucket_prefix                  = var.cache_bucket_prefix
   cache_bucket_name_include_account_id = var.cache_bucket_name_include_account_id
-	cache_bucket_set_random_suffix       = var.cache_bucket_set_random_suffix
+  cache_bucket_set_random_suffix       = var.cache_bucket_set_random_suffix
   cache_bucket_versioning              = var.cache_bucket_versioning
   cache_expiration_days                = var.cache_expiration_days
 }

--- a/modules/cache/README.md
+++ b/modules/cache/README.md
@@ -4,7 +4,7 @@ This sub module creates an S3 bucket for build caches. The cache will have by de
 
 ## Usages
 
-``` 
+```
 
 module "cache" {
   source      = "https://github.com/npalm/terraform-aws-gitlab-runner/tree/move-cache-to-moudle/cache"
@@ -44,6 +44,7 @@ module "runner" {
 | arn\_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions. | `string` | `"arn:aws"` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | `bool` | `true` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | `string` | `""` | no |
+| cache\_bucket\_set\_random\_suffix | `bool` | `false` | no |
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | `string` | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | `number` | `1` | no |
 | cache\_lifecycle\_clear | Enable the rule to cleanup the cache for expired objects. | `bool` | `true` | no |

--- a/modules/cache/README.md
+++ b/modules/cache/README.md
@@ -44,7 +44,7 @@ module "runner" {
 | arn\_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions. | `string` | `"arn:aws"` | no |
 | cache\_bucket\_name\_include\_account\_id | Boolean to add current account ID to cache bucket name. | `bool` | `true` | no |
 | cache\_bucket\_prefix | Prefix for s3 cache bucket name. | `string` | `""` | no |
-| cache\_bucket\_set\_random\_suffix | `bool` | `false` | no |
+| cache\_bucket\_set\_suffix | `bool` | `false` | no |
 | cache\_bucket\_versioning | Boolean used to enable versioning on the cache bucket, false by default. | `string` | `"false"` | no |
 | cache\_expiration\_days | Number of days before cache objects expires. | `number` | `1` | no |
 | cache\_lifecycle\_clear | Enable the rule to cleanup the cache for expired objects. | `bool` | `true` | no |

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 resource "random_string" "s3_suffix" {
-  count   = var.cache_bucket_set_suffix ? 1 : 0
+  count   = var.cache_bucket_set_random_suffix ? 1 : 0
   length  = 8
   upper   = false
   special = false

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -1,5 +1,6 @@
 data "aws_caller_identity" "current" {}
 
+
 locals {
   tags = merge(
     {
@@ -11,7 +12,14 @@ locals {
     var.tags,
   )
 
-  cache_bucket_name = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current.account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
+  cache_bucket_prefix = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current.account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
+  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_prefix, random_string.s3_suffix.result) : local.cache_bucket_prefix
+}
+
+resource "random_string" "s3_suffix" {
+  length  = 8
+  upper   = false
+  special = false
 }
 
 resource "aws_s3_bucket" "build_cache" {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -12,8 +12,8 @@ locals {
     var.tags,
   )
 
-  cache_bucket_prefix = var.cache_bucket_name_include_account_id ? "${var.cache_bucket_prefix}${data.aws_caller_identity.current.account_id}-gitlab-runner-cache" : "${var.cache_bucket_prefix}-gitlab-runner-cache"
-  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_prefix, random_string.s3_suffix.result) : local.cache_bucket_prefix
+  cache_bucket_string = var.cache_bucket_name_include_account_id ? format("%s%s-gitlab-runner-cache", var.cache_bucket_prefix, data.aws_caller_identity.current.account_id) : format("%s-gitlab-runner-cache", var.cache_bucket_prefix)
+  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_string, random_string.s3_suffix.result) : local.cache_bucket_string
 }
 
 resource "random_string" "s3_suffix" {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -13,10 +13,11 @@ locals {
   )
 
   cache_bucket_string = var.cache_bucket_name_include_account_id ? format("%s%s-gitlab-runner-cache", var.cache_bucket_prefix, data.aws_caller_identity.current.account_id) : format("%s-gitlab-runner-cache", var.cache_bucket_prefix)
-  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_string, random_string.s3_suffix.result) : local.cache_bucket_string
+  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_string, random_string.s3_suffix[0].result) : local.cache_bucket_string
 }
 
 resource "random_string" "s3_suffix" {
+  count   = var.cache_bucket_set_suffix ? 1 : 0
   length  = 8
   upper   = false
   special = false

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -13,7 +13,7 @@ locals {
   )
 
   cache_bucket_string = var.cache_bucket_name_include_account_id ? format("%s%s-gitlab-runner-cache", var.cache_bucket_prefix, data.aws_caller_identity.current.account_id) : format("%s-gitlab-runner-cache", var.cache_bucket_prefix)
-  cache_bucket_name   = var.cache_bucket_set_suffix ? format("%s-%s", local.cache_bucket_string, random_string.s3_suffix[0].result) : local.cache_bucket_string
+  cache_bucket_name   = var.cache_bucket_set_random_suffix ? format("%s-%s", local.cache_bucket_string, random_string.s3_suffix[0].result) : local.cache_bucket_string
 }
 
 resource "random_string" "s3_suffix" {

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -9,7 +9,7 @@ variable "cache_bucket_prefix" {
   default     = ""
 }
 
-variable "cache_bucket_set_suffix" {
+variable "cache_bucket_set_random_suffix" {
   description = "Random string suffix for s3 cache bucket"
   type        = bool
   default     = false

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -9,6 +9,12 @@ variable "cache_bucket_prefix" {
   default     = ""
 }
 
+variable "cache_bucket_set_suffix" {
+  description = "Random string suffix for s3 cache bucket"
+  type        = bool
+  default     = false
+}
+
 variable "cache_bucket_name_include_account_id" {
   description = "Boolean to add current account ID to cache bucket name."
   type        = bool

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -9,7 +9,7 @@ variable "cache_bucket_prefix" {
   default     = ""
 }
 
-variable "cache_bucket_set_random_suffix" {
+variable "cache_bucket_set_suffix" {
   description = "Random string suffix for s3 cache bucket"
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -308,6 +308,12 @@ variable "cache_bucket_name_include_account_id" {
   default     = true
 }
 
+variable "cache_bucket_set_random_suffix" {
+  description = "Append the cache bucket name with a random string suffix"
+	type = bool
+	default = false
+}
+
 variable "cache_bucket_versioning" {
   description = "Boolean used to enable versioning on the cache bucket, false by default."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -310,8 +310,8 @@ variable "cache_bucket_name_include_account_id" {
 
 variable "cache_bucket_set_random_suffix" {
   description = "Append the cache bucket name with a random string suffix"
-	type = bool
-	default = false
+  type        = bool
+  default     = false
 }
 
 variable "cache_bucket_versioning" {


### PR DESCRIPTION
Hey Niek! 

Feel free to reject this if you don't think it's useful :) I needed it to quickly recreate the module multiple times without having to change the bucket name in every run 

(as a result of testing some cloud-init userdata changes in our setup).

#### Description

This change adds the option to append a random string suffix to the S3 bucket name. 
As bucket names can only exist once, it's not possible to destroy the module and reinstall after without config changes as the previously used bucket name is not free for use anymore after teardown.  By adding a random string to the bucket name this problem is solved.

This can also be useful if you want to use the same configuration for multiple regions.

#### Migrations required
NO - Not if `cache_bucket_set_suffix` is not set to true.

#### Verification
Not yet! Will test later this week. 

#### Documentation

^ Is this stil actual? I could find the directory anymore. Otherwise I updated the README.md.
