### PR TITLE
Add option to attach additional policies to the runner agent instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ terraform destroy
 | permissions\_boundary | Name of permissions boundary policy to attach to AWS IAM roles | `string` | `""` | no |
 | runner\_ami\_filter | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | `map(list(string))` | <pre>{<br>  "name": [<br>    "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"<br>  ]<br>}</pre> | no |
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | `list(string)` | <pre>[<br>  "099720109477"<br>]</pre> | no |
+| runner\_iam\_policy\_arns | List of policy ARNs to be added to the instance profile of the runners. | `list(string)` | `[]` | no |
 | runner\_instance\_ebs\_optimized | Enable the GitLab runner instance to be EBS-optimized. | `bool` | `true` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | `string` | `null` | no |
 | runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -302,6 +302,14 @@ resource "aws_iam_role_policy_attachment" "instance_session_manager_aws_managed"
   policy_arn = "${var.arn_format}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+################################################################################
+### Add user defined policies
+################################################################################
+resource "aws_iam_role_policy_attachment" "user_defined_policies" {
+  count      = length(var.runner_iam_policy_arns)
+  role       = aws_iam_role.instance.name
+  policy_arn = var.runner_iam_policy_arns[count.index]
+}
 
 ################################################################################
 ### Policy for the docker machine instance to access cache

--- a/variables.tf
+++ b/variables.tf
@@ -581,6 +581,6 @@ variable "log_group_name" {
 
 variable "runner_iam_policy_arns" {
   type        = list(string)
-  description = "List of policy ARNs to be added to the instance profile of the runners."
+  description = "List of policy ARNs to be added to the instance profile of the gitlab runner agent ec2 instance."
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -578,3 +578,9 @@ variable "log_group_name" {
   default     = null
   type        = string
 }
+
+variable "runner_iam_policy_arns" {
+  type        = list(string)
+  description = "List of policy ARNs to be added to the instance profile of the runners."
+  default     = []
+}


### PR DESCRIPTION
## Description
Ability to attach additional policies is quite helfpuf, for example if one would like to use gitlabrunner to build golden AMIs.

## Verification
I have tested proposed changes and was able to deploy and attach additional policy successfully. 