### PR TITLE
Add variable to disable EC2 detailed monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ terraform destroy
 | runner\_ami\_owners | The list of owners used to select the AMI of Gitlab runner docker-machine instances. | `list(string)` | <pre>[<br>  "099720109477"<br>]</pre> | no |
 | runner\_iam\_policy\_arns | List of policy ARNs to be added to the instance profile of the runners. | `list(string)` | `[]` | no |
 | runner\_instance\_ebs\_optimized | Enable the GitLab runner instance to be EBS-optimized. | `bool` | `true` | no |
+| runner\_instance\_enable\_monitoring | Enable the GitLab runner instance to have detailed monitoring. | `bool` | `true` | no |
 | runner\_instance\_spot\_price | By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS. | `string` | `null` | no |
 | runner\_root\_block\_device | The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops` | `map(string)` | `{}` | no |
 | runner\_tags | Map of tags that will be added to runner EC2 instances. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -205,6 +205,7 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
   user_data            = local.template_user_data
   instance_type        = var.instance_type
   ebs_optimized        = var.runner_instance_ebs_optimized
+  enable_monitoring    = var.runner_instance_enable_monitoring
   spot_price           = var.runner_instance_spot_price
   iam_instance_profile = aws_iam_instance_profile.instance.name
   dynamic "root_block_device" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "runner_instance_ebs_optimized" {
   default     = true
 }
 
+variable "runner_instance_enable_monitoring" {
+  description = "Enable the GitLab runner instance to have detailed monitoring."
+  type        = bool
+  default     = true
+}
+
 variable "runner_instance_spot_price" {
   description = "By setting a spot price bid price the runner agent will be created via a spot request. Be aware that spot instances can be stopped by AWS."
   type        = string


### PR DESCRIPTION
## Description
Fixes #259 

I'm running a cheap 💰  cluster and noticed an additional cost being introduced because the Terraform module for `auto_launch_configuration` 
sets `enable_monitoring: true` by default. 

![image](https://user-images.githubusercontent.com/1352979/95396047-4c51a080-0900-11eb-9654-ff12d4b69ebf.png)

There was no variable yet in the module to disable `EC2 Detailed Monitoring` and revert it back to basic monitoring. This PR adds a variable to control that setting. 

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration#enable_monitoring


## Migrations required
No

## Verification
I have verified it in my own project (private Gitlab), which is built on the `runner-default example`, by using:

```
source = "git::https://github.com/jessedobbelaere/terraform-aws-gitlab-runner.git?ref=add-variable-disable-detailed-monitoring"
```

And doing a few Terraform apply's where the variable is enabled or disabled. Works like a charm. 


## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`, requires `terraform-docs` version 0.8+
👍 This `autodocs.sh` file does not exist though? 
