### PR TITLE
Allow custom policies to be attached to the docker machine profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ terraform destroy
 | docker\_machine\_instance\_type | Instance type used for the instances hosting docker-machine. | `string` | `"m5.large"` | no |
 | docker\_machine\_options | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | `list(string)` | `[]` | no |
 | docker\_machine\_role\_json | Docker machine runner instance override policy, expected to be in JSON format. | `string` | `""` | no |
+| docker\_machine\_iam\_policy\_arns | List of policy ARNs to be added to the instance profile of the docker machine runners. | `list(string)` | `[]` | no |
 | docker\_machine\_spot\_price\_bid | Spot price bid. | `string` | `"0.06"` | no |
 | docker\_machine\_version | Version of docker-machine. The version will be ingored once `docker_machine_download_url` is set. | `string` | `"0.16.2"` | no |
 | enable\_asg\_recreation | Enable automatic redeployment of the Runner ASG when the Launch Configs change. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -337,6 +337,16 @@ resource "aws_iam_instance_profile" "docker_machine" {
   role = aws_iam_role.docker_machine.name
 }
 
+################################################################################
+### Add user defined policies
+################################################################################
+resource "aws_iam_role_policy_attachment" "docker_machine_user_defined_policies" {
+  count      = length(var.docker_machine_iam_policy_arns)
+  role       = aws_iam_role.docker_machine.name
+  policy_arn = var.docker_machine_iam_policy_arns[count.index]
+}
+
+################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_session_manager_aws_managed" {
   count = var.enable_docker_machine_ssm_access ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -633,3 +633,9 @@ variable "runner_iam_policy_arns" {
   description = "List of policy ARNs to be added to the instance profile of the runners."
   default     = []
 }
+
+variable "docker_machine_iam_policy_arns" {
+  type        = list(string)
+  description = "List of policy ARNs to be added to the instance profile of the docker machine runners."
+  default     = []
+}


### PR DESCRIPTION
## Description
Provide support for user defined IAM policies to be attached to the docker machine runners. This allows pipelines that need to access IAM resources to have their permissions defined by the docker machine profile.

## Migrations required
NO

## Verification
Ran the ci verification steps. Also tested with my desired use case, attached a custom policy to the docker machine instance role.

## Documentation
Documentation was updated.