### PR TITLE
Adding docker runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ terraform destroy
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | `string` | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | `string` | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | `bool` | `true` | no |
-| runners\_docker\_runtime| Runtime that rocker will be used, will be used in the runner config.toml | `string` | `containerd` | no |
+| runners\_docker\_runtime| Runtime that rocker will be used, will be used in the runner config.toml | `string` | `""` | no |
 | runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | `string` | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | `number` | `1` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ terraform destroy
 | runners\_pre\_build\_script | Script to execute in the pipeline just before the build, will be used in the runner config.toml | `string` | `""` | no |
 | runners\_pre\_clone\_script | Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. | `string` | `""` | no |
 | runners\_privileged | Runners will run in privileged mode, will be used in the runner config.toml | `bool` | `true` | no |
+| runners\_docker\_runtime| Runtime that rocker will be used, will be used in the runner config.toml | `string` | `containerd` | no |
 | runners\_pull\_policy | pull\_policy for the runners, will be used in the runner config.toml | `string` | `"always"` | no |
 | runners\_request\_concurrency | Limit number of concurrent requests for new jobs from GitLab (default 1) | `number` | `1` | no |
 | runners\_request\_spot\_instance | Whether or not to request spot instances via docker-machine | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ locals {
       runners_concurrent                = var.runners_concurrent
       runners_image                     = var.runners_image
       runners_privileged                = var.runners_privileged
+      runners_docker_runtime            = var.runners_docker_runtime
       runners_shm_size                  = var.runners_shm_size
       runners_pull_policy               = var.runners_pull_policy
       runners_idle_count                = var.runners_idle_count

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -21,6 +21,7 @@ check_interval = 0
     volumes = ["/cache"${runners_additional_volumes}]
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
+    runtime = "${runners_docker_runtime}"
   [runners.docker.tmpfs]
     ${runners_volumes_tmpfs}
   [runners.docker.services_tmpfs]

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -64,3 +64,4 @@ check_interval = 0
     ${runners_off_peak_idle_count}
     ${runners_off_peak_idle_time}
     ${runners_off_peak_periods_string}
+    ${runners_machine_autoscaling}

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -64,4 +64,4 @@ check_interval = 0
     ${runners_off_peak_idle_count}
     ${runners_off_peak_idle_time}
     ${runners_off_peak_periods_string}
-    ${runners_machine_autoscaling}
+   ${runners_machine_autoscaling}

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -64,4 +64,3 @@ check_interval = 0
     ${runners_off_peak_idle_count}
     ${runners_off_peak_idle_time}
     ${runners_off_peak_periods_string}
-  ${runners_machine_autoscaling}

--- a/variables.tf
+++ b/variables.tf
@@ -171,6 +171,12 @@ variable "runners_shm_size" {
   default     = 0
 }
 
+variable "runners_docker_runtime" {
+  description = "docker runtime for runners, will be used in the runner config.toml"
+  type        = string
+  default     = "containerd"
+}
+
 variable "runners_pull_policy" {
   description = "pull_policy for the runners, will be used in the runner config.toml"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "runners_shm_size" {
 variable "runners_docker_runtime" {
   description = "docker runtime for runners, will be used in the runner config.toml"
   type        = string
-  default     = "dockerd"
+  default     = ""
 }
 
 variable "runners_pull_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "runners_shm_size" {
 variable "runners_docker_runtime" {
   description = "docker runtime for runners, will be used in the runner config.toml"
   type        = string
-  default     = "containerd"
+  default     = "dockerd"
 }
 
 variable "runners_pull_policy" {


### PR DESCRIPTION
## Description
I was in need of the nvidia docker runtime in order for my gitlab jobs to be able to access the GPUs on the instances I was using and figured that someone else using this module in the future may also like this option.

I found where to add the value in this GitLab ticket https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2465#note_65167962


## Migrations required
NO

## Verification
I have deployed using this version from my github and was able to see the GPU now.

Prior to change:
![image](https://user-images.githubusercontent.com/10335972/101703607-82b6b380-3a48-11eb-9b41-9196eed91bfb.png)

After this change and passing in "nvidia" to the runner_docker_runtime variable:
![image](https://user-images.githubusercontent.com/10335972/101703637-95c98380-3a48-11eb-9cff-720c6dde7d2e.png)


## Documentation
Can't tell if I'm crazy or not, but I can't seem to find the __doc/README.md file, but I updated the one in root
