### PR TITLE
Feat: Support Security Group custom description

### DIFF
--- a/examples/runner-docker/_docs/TF_MODULE.md
+++ b/examples/runner-docker/_docs/TF_MODULE.md
@@ -13,6 +13,8 @@
 | gitlab\_url | URL of the gitlab instance to connect to. | `string` | `"https://gitlab.com"` | no |
 | registration\_token | n/a | `any` | n/a | yes |
 | runner\_name | Name of the runner, will be used in the runner config.toml | `string` | `"docker"` | no |
+| docker_machine_security_group_description | Description for the docker machine security group. | `string` | `"A security group containing docker-machine instances"` | no |
+| gitlab_runner_security_group_description | Name of the timezone that the runner will be used in. | `string` | `"A security group containing gitlab-runner agent instances"` | no |
 
 ## Outputs
 

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -37,6 +37,9 @@ module "runner" {
   runners_use_private_address = false
   enable_eip                  = true
 
+  docker_machine_security_group_description = "Custom description for docker-machine"
+  gitlab_runner_security_group_description = "Custom description for gitlab-runner"
+
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.public_subnets
   subnet_id_runners        = element(module.vpc.public_subnets, 0)

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -38,7 +38,7 @@ module "runner" {
   enable_eip                  = true
 
   docker_machine_security_group_description = "Custom description for docker-machine"
-  gitlab_runner_security_group_description = "Custom description for gitlab-runner"
+  gitlab_runner_security_group_description  = "Custom description for gitlab-runner"
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.public_subnets

--- a/examples/runner-docker/variables.tf
+++ b/examples/runner-docker/variables.tf
@@ -31,5 +31,6 @@ variable "gitlab_url" {
 }
 
 variable "registration_token" {
+  default = "UkCzuTzyM8rBzs68Hpsu"
 }
 

--- a/examples/runner-docker/variables.tf
+++ b/examples/runner-docker/variables.tf
@@ -31,6 +31,5 @@ variable "gitlab_url" {
 }
 
 variable "registration_token" {
-  default = "UkCzuTzyM8rBzs68Hpsu"
 }
 

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -5,7 +5,7 @@
 resource "aws_security_group" "runner" {
   name_prefix = "${var.environment}-security-group"
   vpc_id      = var.vpc_id
-  description = "A security group containing gitlab-runner agent instances"
+  description = var.gitlab_runner_security_group_description
 
   dynamic "egress" {
     for_each = var.gitlab_runner_egress_rules
@@ -123,7 +123,7 @@ resource "aws_security_group_rule" "runner_ping_group" {
 resource "aws_security_group" "docker_machine" {
   name_prefix = "${var.environment}-docker-machine"
   vpc_id      = var.vpc_id
-  description = "A security group containing docker-machine instances"
+  description = var.docker_machine_security_group_description
 
   tags = merge(
     local.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -394,6 +394,12 @@ variable "gitlab_runner_security_group_ids" {
   default     = []
 }
 
+variable "gitlab_runner_security_group_description" {
+  description = "A description for the gitlab-runner security group"
+  type        = string
+  default     = "A security group containing gitlab-runner agent instances"
+}
+
 variable "enable_cloudwatch_logging" {
   description = "Boolean used to enable or disable the CloudWatch logging."
   type        = bool
@@ -446,6 +452,12 @@ variable "docker_machine_role_json" {
   description = "Docker machine runner instance override policy, expected to be in JSON format."
   type        = string
   default     = ""
+}
+
+variable "docker_machine_security_group_description" {
+  description = "A description for the docker-machine security group"
+  type        = string
+  default     = "A security group containing docker-machine instances"
 }
 
 variable "ami_filter" {


### PR DESCRIPTION
## Description
Just a small update to be able to customize the security groups description for both gitlab runner and docker machine instances.

## Migrations required
 NO

## Verification
Verified on runner-docker example

## Documentation
Documentation updated in runner-docker example

Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`, requires `terraform-docs` version 0.8+


