### PR TITLE
fix: failing pip install for assigning eip

### DIFF
--- a/template/eip.tpl
+++ b/template/eip.tpl
@@ -1,9 +1,10 @@
 echo 'installing additional software for assigning EIP'
 
+yum install python3 -y
 curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
-python get-pip.py --user
+python3 get-pip.py --user
 export PATH=~/.local/bin:$PATH
 
 pip install aws-ec2-assign-elastic-ip
 export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
-/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}
+/usr/local/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}


### PR DESCRIPTION
## Description
Fix for #279 

## Migrations required
No

## Verification
Default example with eip enabled

