### PR TITLE
fix: explicitly pulls in the Python2.7 get-pip script

### DIFF
--- a/template/eip.tpl
+++ b/template/eip.tpl
@@ -1,7 +1,7 @@
 echo 'installing additional software for assigning EIP'
 
 yum install python3 -y
-curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
+curl --fail --retry 6 -O https://bootstrap.pypa.io/2.7/get-pip.py
 python3 get-pip.py --user
 export PATH=~/.local/bin:$PATH
 


### PR DESCRIPTION
## Description
Currently new nodes are not coming up as the bootstrapping script being fetched is meant for Python3 NOT Python2.7

## Migrations required
NO

## Verification
User data script execution failure extract:
```
+ python get-pip.py --user
Traceback (most recent call last):
  File "get-pip.py", line 24244, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpnuTkF8/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
```

Other mentions of the problem https://stackoverflow.com/questions/65896334/python-pip-broken-wiith-sys-stderr-writeferror-exc

## Documentation
Please ensure you update the README in `_docs/README.md`. The README.md in the root can be updated by running the script `ci/bin/autodocs.sh`, requires `terraform-docs` version 0.8+
