### PR TITLE
Restrict public access and public objects for cache bucket

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -61,6 +61,16 @@ resource "aws_s3_bucket" "build_cache" {
   }
 }
 
+# block public access to S3 cache bucket
+resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
+  bucket = local.cache_bucket_name
+
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}
+
 resource "aws_iam_policy" "docker_machine_cache" {
   count = var.create_cache_bucket ? 1 : 0
 


### PR DESCRIPTION
## Description

This PR entirely restricts the public access to the cache bucket. Currently, the bucket is private via ` acl    = "private"` but objects might be set to public via an owner (not likely but AWS shows a arning, so this is merely a security/warning fix). This is shown as a warning in the AWS UI (see images - sory for german UI). The PR resolves these warnings. Functionality should not be affected as all runners have an access policy for the bucket.

![image](https://user-images.githubusercontent.com/2141507/107847259-558cd580-6dea-11eb-9fce-3268a46e57e6.png)

![image](https://user-images.githubusercontent.com/2141507/107847260-59205c80-6dea-11eb-9e0b-fa52f7b20b13.png)

## Migrations required

NO

## Verification

Used in my deployment.

## Documentation

No documentation needed, buckets are already private as default and its not changeable.

