### PR TITLE
fix: respect create_cache_bucket variable and avoid concurrent change…

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -63,7 +63,9 @@ resource "aws_s3_bucket" "build_cache" {
 
 # block public access to S3 cache bucket
 resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
-  bucket = local.cache_bucket_name
+  count = var.create_cache_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.build_cache[0].id
 
   block_public_acls       = true
   block_public_policy     = true


### PR DESCRIPTION
## Description

I missed two problems with my previous PR (https://github.com/npalm/terraform-aws-gitlab-runner/pull/295):
- respect `create_cache_bucket` variable 
- avoid concurrent changes to cache bucket (apply policy only after bucket is created)

Sorry for my mistakes!

## Migrations required

NO

## Verification

I have tested this with a staging deployment.
