### PR TITLE
make aws_s3_bucket_public_access_block conditional

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -63,6 +63,7 @@ resource "aws_s3_bucket" "build_cache" {
 
 # block public access to S3 cache bucket
 resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
+  count  = var.create_cache_bucket ? 1 : 0
   bucket = local.cache_bucket_name
 
   block_public_acls       = true


### PR DESCRIPTION
aws_s3_bucket_public_access_block should be applied only when module is managing cache bucket (var.create_cache_bucket)

## Description

A few sentences describing the overall goals of the pull request's commits.

## Migrations required

YES | NO - If yes please describe the migration.

## Verification

Please mention the examples you have verified.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

