### PR TITLE
Fix/autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,38 @@ terraform destroy
 | aws | n/a |
 | null | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| cache | ./modules/cache |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) |
+| [aws_autoscaling_schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) |
+| [aws_availability_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zone) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
+| [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) |
+| [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -331,8 +363,8 @@ terraform destroy
 | runners\_max\_builds | Max builds for each runner after which it will be removed, will be used in the runner config.toml. By default set to 0, no maxBuilds will be set in the configuration. | `number` | `0` | no |
 | runners\_monitoring | Enable detailed cloudwatch monitoring for spot instances. | `bool` | `false` | no |
 | runners\_name | Name of the runner, will be used in the runner config.toml. | `string` | n/a | yes |
-| runners\_off\_peak\_idle\_count | Deprecated, please use `runners_machine_autoscaling`. Off peak idle count of the runners, will be used in the runner config.toml. | `string` | `-1` | no |
-| runners\_off\_peak\_idle\_time | Deprecated, please use `runners_machine_autoscaling`. Off peak idle time of the runners, will be used in the runner config.toml. | `string` | `-1` | no |
+| runners\_off\_peak\_idle\_count | Deprecated, please use `runners_machine_autoscaling`. Off peak idle count of the runners, will be used in the runner config.toml. | `number` | `-1` | no |
+| runners\_off\_peak\_idle\_time | Deprecated, please use `runners_machine_autoscaling`. Off peak idle time of the runners, will be used in the runner config.toml. | `number` | `-1` | no |
 | runners\_off\_peak\_periods | Deprecated, please use `runners_machine_autoscaling`. Off peak periods of the runners, will be used in the runner config.toml. | `string` | `null` | no |
 | runners\_off\_peak\_timezone | Deprecated, please use `runners_machine_autoscaling`. Off peak idle time zone of the runners, will be used in the runner config.toml. | `string` | `null` | no |
 | runners\_output\_limit | Sets the maximum build log size in kilobytes, by default set to 4096 (4MB) | `number` | `4096` | no |
@@ -373,7 +405,6 @@ terraform destroy
 | runner\_role\_arn | ARN of the role used for the docker machine runners. |
 | runner\_role\_name | Name of the role used for the docker machine runners. |
 | runner\_sg\_id | ID of the security group attached to the docker machine runners. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributors ✨

--- a/modules/cache/README.md
+++ b/modules/cache/README.md
@@ -38,6 +38,20 @@ module "runner" {
 | aws | n/a |
 | random | n/a |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -61,5 +75,4 @@ module "runner" {
 | arn | The ARN of the created bucket. |
 | bucket | Name of the created bucket. |
 | policy\_arn | Policy for users of the cache (bucket). |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -65,4 +65,4 @@ check_interval = 0
     ${runners_off_peak_idle_count}
     ${runners_off_peak_idle_time}
     ${runners_off_peak_periods_string}
-   ${runners_machine_autoscaling}
+${runners_machine_autoscaling}

--- a/template/runners_machine_autoscaling.tpl
+++ b/template/runners_machine_autoscaling.tpl
@@ -1,6 +1,6 @@
 %{ for config in runners_machine_autoscaling ~}
    [[runners.machine.autoscaling]]
-    Periods = ["${join(",", config.periods)}"]
+    Periods = [${replace(format("\"%s\"", join("\",\"", config.periods)), "/\"{2,}/", "\"")}]
     IdleCount = ${config.idle_count}
     IdleTime = ${config.idle_time}
     Timezone = "${config.timezone}"

--- a/template/runners_machine_autoscaling.tpl
+++ b/template/runners_machine_autoscaling.tpl
@@ -1,6 +1,6 @@
 %{ for config in runners_machine_autoscaling ~}
-[[runners.machine.autoscaling]]
-    Periods = [${join(",", config.periods)}]
+   [[runners.machine.autoscaling]]
+    Periods = ["${join(",", config.periods)}"]
     IdleCount = ${config.idle_count}
     IdleTime = ${config.idle_time}
     Timezone = "${config.timezone}"

--- a/variables.tf
+++ b/variables.tf
@@ -209,13 +209,13 @@ variable "runners_off_peak_timezone" {
 
 variable "runners_off_peak_idle_count" {
   description = "Deprecated, please use `runners_machine_autoscaling`. Off peak idle count of the runners, will be used in the runner config.toml."
-  type        = string
+  type        = number
   default     = -1
 }
 
 variable "runners_off_peak_idle_time" {
   description = "Deprecated, please use `runners_machine_autoscaling`. Off peak idle time of the runners, will be used in the runner config.toml."
-  type        = string
+  type        = number
   default     = -1
 }
 


### PR DESCRIPTION
## Description

The pull request is to fix the auto-scaling configuration using object variable rather than individual variables.

Two variables had wrong typing so they were being put in config.toml even if set to -1 which should have resulted in those to return empty strings but they were filled with the values has -1 each.

```
${runners_off_peak_idle_count}
${runners_off_peak_idle_time}
```

The 3 spaces for the object-based auto-scaling config was shifted from "template/runner-config.tpl" to "template/runners_machine_autoscaling.tpl" since that particular space placement made it so only the first set of 
"[[runners.machine.autoscaling]]" were preceded by 3 spaces

Finally, line 3 of "template/runners_machine_autoscaling.tpl" was missing surrounding double-quotes that would also yield invalid configuration.

## Migrations required

NO (Shouldn't be at least seeing as setting up auto-scaling using the object variable is currently not working)

## Verification

None of the examples currently use the object configuration method rather than the method marked as deprecated.

The parameter used to test was : 

```
runners_machine_autoscaling = [
    {
      timezone   = var.timezone
      idle_count = 0
      idle_time  = 60
      periods = ["* * 0-7,18-23 * * mon-fri *"]
    },
    {
      timezone   = var.timezone
      idle_count = 0
      idle_time  = 60
      periods = ["* * * * * sat,sun *"]
    }
  ]
```

## Documentation

pre-commit script were run and passed

