### PR TITLE
feat: additional config parameter asg_delete_timeout to configure the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ terraform destroy
 | docker\_machine\_spot\_price\_bid | Spot price bid. | `string` | `"0.06"` | no |
 | docker\_machine\_version | By default docker\_machine\_download\_url is used to set the docker machine version. Version of docker-machine. The version will be ingored once `docker_machine_download_url` is set. | `string` | `""` | no |
 | enable\_asg\_recreation | Enable automatic redeployment of the Runner ASG when the Launch Configs change. | `bool` | `true` | no |
+| asg\_delete\_timeout | Timeout when trying to delete the Runner ASG. | `string` | `"10m"` | no |
 | enable\_cloudwatch\_logging | Boolean used to enable or disable the CloudWatch logging. | `bool` | `true` | no |
 | enable\_docker\_machine\_ssm\_access | Add IAM policies to the docker-machine instances to connect via the Session Manager. | `bool` | `false` | no |
 | enable\_eip | Enable the assignment of an EIP to the gitlab runner instance | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,9 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   launch_configuration      = aws_launch_configuration.gitlab_runner_instance.name
   enabled_metrics           = var.metrics_autoscaling
   tags                      = data.null_data_source.agent_tags.*.outputs
+  timeouts {
+    delete = var.asg_delete_timeout
+  }
 }
 
 resource "aws_autoscaling_schedule" "scale_in" {

--- a/variables.tf
+++ b/variables.tf
@@ -640,6 +640,12 @@ variable "enable_asg_recreation" {
   type        = bool
 }
 
+variable "asg_delete_timeout" {
+  description = "Timeout when trying to delete the Runner ASG."
+  default     = "10m"
+  type        = string
+}
+
 variable "enable_forced_updates" {
   description = "DEPRECATED! and is replaced by `enable_asg_recreation. Setting this variable to true will do the oposite as expected. For backward compatibility the variable will remain some releases. Old desription: Enable automatic redeployment of the Runner ASG when the Launch Configs change."
   default     = null


### PR DESCRIPTION
## Description

To gracefully shutdown the GitLab runner, the deletion of the corresponding AutoScalingGroup might take more than the default timeout of 10 minutes.
Therefore, I added another config parameter to be able to increase the value accordingly.

## Migrations required

NO - default value matches to the [Terraform default value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#delete)

## Verification

Tested in my local environment.

## Documentation

I added the new config parameter to the README.
