### PR TITLE
Add count statement to build cache policy

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -63,6 +63,8 @@ resource "aws_s3_bucket" "build_cache" {
 
 # block public access to S3 cache bucket
 resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
+  count = var.create_cache_bucket ? 1 : 0
+  
   bucket = local.cache_bucket_name
 
   block_public_acls       = true


### PR DESCRIPTION
If create_cache_bucket is set to false, we don't want to build the S3 policy, this line should stop that from happening