### PR TITLE
feat: amazon-ecr-credential-helper

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -48,6 +48,9 @@ docker-machine rm -y dummy-machine
 unset HOME
 unset USER
 
+# Install amazon-ecr-credential-helper
+yum install amazon-ecr-credential-helper -y
+
 # Install jq if not exists
 if ! [ -x "$(command -v jq)" ]; then
   yum install jq -y


### PR DESCRIPTION
depends on npalm/terraform-aws-gitlab-runner#271

## Description

It's will be awesome if we can use ECR credentials helper in runner

## Migrations required

NO

## Verification

## Documentation


