### PR TITLE
feat: Add tags to aws_iam_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
+| aws | >= 3.35.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.35.0 |
 | null | n/a |
 
 ## Modules

--- a/examples/runner-default/versions.tf
+++ b/examples/runner-default/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.23"
+      version = "~> 3.35"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/runner-docker/versions.tf
+++ b/examples/runner-docker/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.23"
+      version = "~> 3.35"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/runner-pre-registered/versions.tf
+++ b/examples/runner-pre-registered/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.23"
+      version = "~> 3.35"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/runner-public/versions.tf
+++ b/examples/runner-public/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.23"
+      version = "~> 3.35"
     }
     local = {
       source  = "hashicorp/local"

--- a/main.tf
+++ b/main.tf
@@ -266,6 +266,7 @@ resource "aws_iam_role" "instance" {
   name                 = "${var.environment}-instance-role"
   assume_role_policy   = length(var.instance_role_json) > 0 ? var.instance_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
+  tags                 = local.tags
 }
 
 ################################################################################
@@ -275,8 +276,8 @@ resource "aws_iam_policy" "instance_docker_machine_policy" {
   name        = "${var.environment}-docker-machine"
   path        = "/"
   description = "Policy for docker machine."
-
-  policy = templatefile("${path.module}/policies/instance-docker-machine-policy.json", {})
+  policy      = templatefile("${path.module}/policies/instance-docker-machine-policy.json", {})
+  tags        = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "instance_docker_machine_policy" {
@@ -293,8 +294,8 @@ resource "aws_iam_policy" "instance_session_manager_policy" {
   name        = "${var.environment}-session-manager"
   path        = "/"
   description = "Policy session manager."
-
-  policy = templatefile("${path.module}/policies/instance-session-manager-policy.json", {})
+  policy      = templatefile("${path.module}/policies/instance-session-manager-policy.json", {})
+  tags        = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "instance_session_manager_policy" {
@@ -336,11 +337,13 @@ resource "aws_iam_role" "docker_machine" {
   name                 = "${var.environment}-docker-machine-role"
   assume_role_policy   = length(var.docker_machine_role_json) > 0 ? var.docker_machine_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
+  tags                 = local.tags
 }
 
 resource "aws_iam_instance_profile" "docker_machine" {
   name = "${var.environment}-docker-machine-profile"
   role = aws_iam_role.docker_machine.name
+  tags = local.tags
 }
 
 ################################################################################
@@ -369,8 +372,8 @@ resource "aws_iam_policy" "service_linked_role" {
   name        = "${var.environment}-service_linked_role"
   path        = "/"
   description = "Policy for creation of service linked roles."
-
-  policy = templatefile("${path.module}/policies/service-linked-role-create-policy.json", { arn_format = var.arn_format })
+  policy      = templatefile("${path.module}/policies/service-linked-role-create-policy.json", { arn_format = var.arn_format })
+  tags        = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "service_linked_role" {
@@ -393,8 +396,8 @@ resource "aws_iam_policy" "ssm" {
   name        = "${var.environment}-ssm"
   path        = "/"
   description = "Policy for runner token param access via SSM"
-
-  policy = templatefile("${path.module}/policies/instance-secure-parameter-role-policy.json", { arn_format = var.arn_format })
+  policy      = templatefile("${path.module}/policies/instance-secure-parameter-role-policy.json", { arn_format = var.arn_format })
+  tags        = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
@@ -413,8 +416,8 @@ resource "aws_iam_policy" "eip" {
   name        = "${var.environment}-eip"
   path        = "/"
   description = "Policy for runner to assign EIP"
-
-  policy = templatefile("${path.module}/policies/instance-eip.json", {})
+  policy      = templatefile("${path.module}/policies/instance-eip.json", {})
+  tags        = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "eip" {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -79,6 +79,7 @@ resource "aws_iam_policy" "docker_machine_cache" {
   name        = "${var.environment}-docker-machine-cache"
   path        = "/"
   description = "Policy for docker machine instance to access cache"
+  tags        = local.tags
 
   policy = templatefile("${path.module}/policies/cache.json",
     {

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,8 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 3.35.0"
+      source  = "hashicorp/aws"
     }
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
## Description

- Add tagging to aws_iam_policy supported by AWS provider 3.35
- Fix #315 


## Migrations required

NO, upgrade to aws provider 3.35 required

## Verification

Default example
