### PR TITLE
Fix: S3 cache creation conflicts

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -92,7 +92,7 @@ resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
   restrict_public_buckets = true
   ignore_public_acls      = true
 
-  depends_on = ["aws_s3_bucket.build_cache"]
+  depends_on = [aws_s3_bucket.build_cache]
 }
 
 resource "aws_iam_policy" "docker_machine_cache" {
@@ -109,5 +109,5 @@ resource "aws_iam_policy" "docker_machine_cache" {
     }
   )
 
-  depends_on = ["aws_s3_bucket_public_access_block.build_cache_policy"]
+  depends_on = [aws_s3_bucket_public_access_block.build_cache_policy]
 }

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -91,6 +91,8 @@ resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
   block_public_policy     = true
   restrict_public_buckets = true
   ignore_public_acls      = true
+
+  depends_on = ["aws_s3_bucket.build_cache"]
 }
 
 resource "aws_iam_policy" "docker_machine_cache" {
@@ -106,4 +108,6 @@ resource "aws_iam_policy" "docker_machine_cache" {
       s3_cache_arn = var.create_cache_bucket == false || length(aws_s3_bucket.build_cache) == 0 ? "${var.arn_format}:s3:::fake_bucket_doesnt_exist" : aws_s3_bucket.build_cache[0].arn
     }
   )
+
+  depends_on = ["aws_s3_bucket_public_access_block.build_cache_policy"]
 }


### PR DESCRIPTION
## Description

When using this terraform to create GitLab Runners in AWS, I ran into issues with creating the S3 cache bucket using the cache module.  The issues were around conflicting conditional operations currently in progress, and they happened after repeated runs.  I received the follow errors:

`Error: error updating S3 Bucket (<account id>-gitlab-runner-cache) tags: error setting resource tags (<account id>-gitlab-runner-cache): OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.`

`Error: error putting S3 server side encryption configuration: OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.`

Each time the status code was 409.  I did some research and came across this issue with the AWS Terraform provider: https://github.com/hashicorp/terraform-provider-aws/issues/7628

The workaround suggested there was to add `depends_on` to some of the S3 resources.  I made this change and now the S3 cache bucket is able to be created successfully.

## Migrations required

NO

## Verification

I ran the terraform from my fork successfully in my AWS account; the cache bucket was created successfully without any conflicting operation errors.

## Documentation

N/A

