### PR TITLE
fix: add tags for instance profile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -261,6 +261,7 @@ module "cache" {
 resource "aws_iam_instance_profile" "instance" {
   name = "${var.environment}-instance-profile"
   role = aws_iam_role.instance.name
+  tags = local.tags
 }
 
 resource "aws_iam_role" "instance" {


### PR DESCRIPTION
the resource "aws_iam_instance_profile" "instance"  has not tags, we need the tags for policy verification purposes