### PR TITLE
Add `role_tags` to support tag based authorization (#333)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,7 @@ resource "aws_iam_role" "instance" {
   name                 = "${var.environment}-instance-role"
   assume_role_policy   = length(var.instance_role_json) > 0 ? var.instance_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
-  tags                 = local.tags
+  tags                 = merge(local.tags, var.role_tags)
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -448,6 +448,12 @@ variable "runner_tags" {
   default     = {}
 }
 
+variable "role_tags" {
+  description = "Map of tags that will be added to the role created. Useful for tag based authorization."
+  type        = map(string)
+  default     = {}
+}
+
 variable "allow_iam_service_linked_role_creation" {
   description = "Boolean used to control attaching the policy to a runner instance to create service linked roles."
   type        = bool


### PR DESCRIPTION
## Description

As described in #333 it is useful to have special tags to add to the `aws_iam_role` to allow tag based authorization. As these tags are needed on the role only I introduced a new variable `role_tags` for them.

## Migrations required

NO

## Verification

Plan checked
```
  + tags                  = {
          + "Environment"                  = "prod-gitlab-ci-runner-non-terraform"
          + "Name"                         = "prod-gitlab-ci-runner-non-terraform"
          + "allowReadPlatformCredentials" = "gitlab-ci-runner"     # <<< role_tags
          + "app"                          = "runner"
          + "environment"                  = "prod"
          + "service"                      = "gitlab-ci"
          + "team"                         = "sales"
```