### PR TITLE
fix: replace deprecated null_data_source with locals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Module directory
 .terraform/
+.terraform.lock.hcl
 
 # keys
 *id_rsa*

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   health_check_grace_period = 0
   launch_configuration      = aws_launch_configuration.gitlab_runner_instance.name
   enabled_metrics           = var.metrics_autoscaling
-  tags                      = data.null_data_source.agent_tags.*.outputs
+  tags                      = local.agent_tags_propagated
   timeouts {
     delete = var.asg_delete_timeout
   }

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "remove_runner" {
 }
 
 locals {
-  enable_asg_recreation = var.enable_forced_updates != null ? !var.enable_forced_updates : var.enable_asg_recreation
+  enable_asg_recreation = var.enable_forced_updates != null ? ! var.enable_forced_updates : var.enable_asg_recreation
 
   template_user_data = templatefile("${path.module}/template/user-data.tpl",
     {
@@ -125,7 +125,7 @@ locals {
       runners_root_size                 = var.runners_root_size
       runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
       runners_use_private_address_only  = var.runners_use_private_address
-      runners_use_private_address       = !var.runners_use_private_address
+      runners_use_private_address       = ! var.runners_use_private_address
       runners_request_spot_instance     = var.runners_request_spot_instance
       runners_environment_vars          = jsonencode(var.runners_environment_vars)
       runners_pre_build_script          = var.runners_pre_build_script

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "remove_runner" {
 }
 
 locals {
-  enable_asg_recreation = var.enable_forced_updates != null ? ! var.enable_forced_updates : var.enable_asg_recreation
+  enable_asg_recreation = var.enable_forced_updates != null ? !var.enable_forced_updates : var.enable_asg_recreation
 
   template_user_data = templatefile("${path.module}/template/user-data.tpl",
     {
@@ -125,7 +125,7 @@ locals {
       runners_root_size                 = var.runners_root_size
       runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
       runners_use_private_address_only  = var.runners_use_private_address
-      runners_use_private_address       = ! var.runners_use_private_address
+      runners_use_private_address       = !var.runners_use_private_address
       runners_request_spot_instance     = var.runners_request_spot_instance
       runners_environment_vars          = jsonencode(var.runners_environment_vars)
       runners_pre_build_script          = var.runners_pre_build_script

--- a/tags.tf
+++ b/tags.tf
@@ -19,6 +19,7 @@ locals {
     var.tags,
     var.agent_tags
   )
+  agent_tags_propagated = [ for tag_key, tag_value in local.agent_tags: { key=tag_key, value=tag_value, propagate_at_launch = true }]
 
   tags_string = join(",", flatten([
     for key in keys(local.tags) : [key, lookup(local.tags, key)]
@@ -27,24 +28,4 @@ locals {
   runner_tags_string = join(",", flatten([
     for key in keys(var.runner_tags) : [key, lookup(var.runner_tags, key)]
   ]))
-}
-
-data "null_data_source" "tags" {
-  count = length(local.tags)
-
-  inputs = {
-    key                 = element(keys(local.tags), count.index)
-    value               = element(values(local.tags), count.index)
-    propagate_at_launch = "true"
-  }
-}
-
-data "null_data_source" "agent_tags" {
-  count = length(local.agent_tags)
-
-  inputs = {
-    key                 = element(keys(local.agent_tags), count.index)
-    value               = element(values(local.agent_tags), count.index)
-    propagate_at_launch = "true"
-  }
 }

--- a/tags.tf
+++ b/tags.tf
@@ -19,7 +19,7 @@ locals {
     var.tags,
     var.agent_tags
   )
-  agent_tags_propagated = [ for tag_key, tag_value in local.agent_tags: { key=tag_key, value=tag_value, propagate_at_launch = true }]
+  agent_tags_propagated = [for tag_key, tag_value in local.agent_tags : { key = tag_key, value = tag_value, propagate_at_launch = true }]
 
   tags_string = join(",", flatten([
     for key in keys(local.tags) : [key, lookup(local.tags, key)]


### PR DESCRIPTION
## Description

null_data_source should not be used anymore.
Terraform locals should be used instead.

A warning is displayed with terraform 1.0.1.

## Migrations required

 NO


