### PR TITLE
feat: replace launch configuration with launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -274,7 +274,8 @@ resource "aws_launch_template" "gitlab_runner_instance" {
       tags = local.tags
     }
   }
-  tags = local.tags  lifecycle {
+  tags = local.tags
+  lifecycle {
     create_before_destroy = true
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -281,8 +281,6 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     http_tokens   = var.runner_instance_metadata_options_http_tokens
   }
 
-  associate_public_ip_address = false == var.runners_use_private_address
-
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
       device_name = lookup(block_device_mappings.value, "device_name", "/dev/xvda")
       ebs {
         delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", true)
-        volume_type           = lookup(block_device_mappings.value, "volume_type", "gp2")
+        volume_type           = lookup(block_device_mappings.value, "volume_type", "gp3")
         volume_size           = lookup(block_device_mappings.value, "volume_size", 8)
         encrypted             = lookup(block_device_mappings.value, "encrypted", true)
         iops                  = lookup(block_device_mappings.value, "iops", null)

--- a/main.tf
+++ b/main.tf
@@ -222,7 +222,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
   name_prefix            = var.runners_name
   key_name               = var.ssh_key_pair
   image_id               = data.aws_ami.runner.id
-  user_data              = local.template_user_data
+  user_data              = base64encode(local.template_user_data)
   instance_type          = var.instance_type
   update_default_version = true
   ebs_optimized          = var.runner_instance_ebs_optimized

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "remove_runner" {
 }
 
 locals {
-  enable_asg_recreation = var.enable_forced_updates != null ? ! var.enable_forced_updates : var.enable_asg_recreation
+  enable_asg_recreation = var.enable_forced_updates != null ? !var.enable_forced_updates : var.enable_asg_recreation
 
   template_user_data = templatefile("${path.module}/template/user-data.tpl",
     {
@@ -125,7 +125,7 @@ locals {
       runners_root_size                 = var.runners_root_size
       runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
       runners_use_private_address_only  = var.runners_use_private_address
-      runners_use_private_address       = ! var.runners_use_private_address
+      runners_use_private_address       = !var.runners_use_private_address
       runners_request_spot_instance     = var.runners_request_spot_instance
       runners_environment_vars          = jsonencode(var.runners_environment_vars)
       runners_pre_build_script          = var.runners_pre_build_script
@@ -219,17 +219,17 @@ data "aws_ami" "runner" {
 }
 
 resource "aws_launch_template" "gitlab_runner_instance" {
-  name_prefix   = var.runners_name
-  key_name      = var.ssh_key_pair
-  image_id      = data.aws_ami.runner.id
-  user_data     = local.template_user_data
-  instance_type = var.instance_type
+  name_prefix            = var.runners_name
+  key_name               = var.ssh_key_pair
+  image_id               = data.aws_ami.runner.id
+  user_data              = local.template_user_data
+  instance_type          = var.instance_type
   update_default_version = true
-  ebs_optimized = var.runner_instance_ebs_optimized
+  ebs_optimized          = var.runner_instance_ebs_optimized
   monitoring {
     enabled = var.runner_instance_enable_monitoring
   }
-  dynamic instance_market_options {
+  dynamic "instance_market_options" {
     for_each = var.runner_instance_spot_price != null && length(var.runner_instance_spot_price) == 0 ? [] : ["spot"]
     content {
       market_type = instance_market_options.value
@@ -268,10 +268,10 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     tags          = local.tags
   }
   dynamic "tag_specifications" {
-    for_each = var.runner_instance_spot_price != null && length(var.runner_instance_spot_price) == 0 ? []: ["spot"]
+    for_each = var.runner_instance_spot_price != null && length(var.runner_instance_spot_price) == 0 ? [] : ["spot"]
     content {
       resource_type = "spot-instances-request"
-      tags = local.tags
+      tags          = local.tags
     }
   }
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "remove_runner" {
 }
 
 locals {
-  enable_asg_recreation = var.enable_forced_updates != null ? !var.enable_forced_updates : var.enable_asg_recreation
+  enable_asg_recreation = var.enable_forced_updates != null ? ! var.enable_forced_updates : var.enable_asg_recreation
 
   template_user_data = templatefile("${path.module}/template/user-data.tpl",
     {
@@ -125,7 +125,7 @@ locals {
       runners_root_size                 = var.runners_root_size
       runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
       runners_use_private_address_only  = var.runners_use_private_address
-      runners_use_private_address       = !var.runners_use_private_address
+      runners_use_private_address       = ! var.runners_use_private_address
       runners_request_spot_instance     = var.runners_request_spot_instance
       runners_environment_vars          = jsonencode(var.runners_environment_vars)
       runners_pre_build_script          = var.runners_pre_build_script

--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     tags          = local.tags
   }
   dynamic "tag_specifications" {
-    for_each = var.runner_instance_spot_price != null && length(var.runner_instance_spot_price) == 0 ? [] : ["spot"]
+    for_each = var.runner_instance_spot_price == null || var.runner_instance_spot_price == "" ? ["spot"] : []
     content {
       resource_type = "spot-instances-request"
       tags          = local.tags

--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     tags          = local.tags
   }
   dynamic "tag_specifications" {
-    for_each = var.runner_instance_spot_price == null || var.runner_instance_spot_price == "" ? ["spot"] : []
+    for_each = var.runner_instance_spot_price == null || var.runner_instance_spot_price == "" ? [] : ["spot"]
     content {
       resource_type = "spot-instances-request"
       tags          = local.tags

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     enabled = var.runner_instance_enable_monitoring
   }
   dynamic "instance_market_options" {
-    for_each = var.runner_instance_spot_price != null && length(var.runner_instance_spot_price) == 0 ? [] : ["spot"]
+    for_each = var.runner_instance_spot_price == null || var.runner_instance_spot_price == "" ? [] : ["spot"]
     content {
       market_type = instance_market_options.value
       spot_options {

--- a/variables.tf
+++ b/variables.tf
@@ -589,7 +589,7 @@ variable "schedule_config" {
 }
 
 variable "runner_root_block_device" {
-  description = "The EC2 instance root block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops`"
+  description = "The EC2 instance root block device configuration. Takes the following keys: `device_name`, `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops`, `kms_key_id`"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Description

AWS recommend that we should use launch templates instead of launch configurations.

With the launch template, we can now use a CMK for storage encryption. Globally, launch template allows
to configure more things than the launch configuration.

## Migrations required

NO
