### PR TITLE
feat: Parametrize runner instance launch configuration metadata options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,8 +227,8 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
     }
   }
   metadata_options {
-    http_endpoint               = var.runner_instance_metadata_options_http_endpoint
-    http_tokens                 = var.runner_instance_metadata_options_http_tokens
+    http_endpoint = var.runner_instance_metadata_options_http_endpoint
+    http_tokens   = var.runner_instance_metadata_options_http_tokens
   }
 
   associate_public_ip_address = false == var.runners_use_private_address

--- a/main.tf
+++ b/main.tf
@@ -226,6 +226,10 @@ resource "aws_launch_configuration" "gitlab_runner_instance" {
       iops                  = lookup(root_block_device.value, "iops", null)
     }
   }
+  metadata_options {
+    http_endpoint               = var.runner_instance_metadata_options_http_endpoint
+    http_tokens                 = var.runner_instance_metadata_options_http_tokens
+  }
 
   associate_public_ip_address = false == var.runners_use_private_address
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,18 @@ variable "runner_instance_spot_price" {
   default     = null
 }
 
+variable "runner_instance_metadata_options_http_endpoint" {
+  description = "Enable the Gitlab runner instance metadata service. The allowed values are enabled, disabled."
+  type        = string
+  default     = "enabled"
+}
+
+variable "runner_instance_metadata_options_http_tokens" {
+  description = "Set if Gitlab runner instance metadata service session tokens are required. The allowed values are optional, required."
+  type        = string
+  default     = "optional"
+}
+
 variable "ssh_key_pair" {
   description = "Set this to use existing AWS key pair"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "runner_instance_spot_price" {
 }
 
 variable "runner_instance_metadata_options_http_endpoint" {
-  description = "Enable the Gitlab runner instance metadata service. The allowed values are enabled, disabled."
+  description = "Enable the Gitlab runner agent instance metadata service. The allowed values are enabled, disabled."
   type        = string
   default     = "enabled"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "runner_instance_metadata_options_http_endpoint" {
 }
 
 variable "runner_instance_metadata_options_http_tokens" {
-  description = "Set if Gitlab runner instance metadata service session tokens are required. The allowed values are optional, required."
+  description = "Set if Gitlab runner agent instance metadata service session tokens are required. The allowed values are optional, required."
   type        = string
   default     = "optional"
 }


### PR DESCRIPTION
## Description

Parametrize usage of Gitlab runner agent instance AWS metadata service  in launch configuration. This enables control of instance AWS IMDSv1 and IMDSv2 options and enables mitigation of AWS Security Hub issue related to IMDSv1 being enabled (EC2 instances should use Instance Metadata Service Version 2 (IMDSv2))

## Migrations required

NO

## Verification

Launch configuration AWS metadata service options change based on input variables given to the module.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

