### PR TITLE
Support for setting Sentry DSN

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,8 @@ locals {
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
 
   // Define key for runner token for SSM
-  secure_parameter_store_runner_token_key = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
+  secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
+  secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
 
   // custom names for instances and security groups
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,18 @@ resource "null_resource" "remove_runner" {
   }
 }
 
+resource "aws_ssm_parameter" "runner_sentry_dsn" {
+  name  = local.secure_parameter_store_runner_sentry_dsn
+  type  = "SecureString"
+  value = "null"
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 locals {
   enable_asg_recreation = var.enable_forced_updates != null ? ! var.enable_forced_updates : var.enable_asg_recreation
 
@@ -65,6 +77,7 @@ locals {
       runners_gitlab_url                           = var.runners_gitlab_url
       runners_token                                = var.runners_token
       secure_parameter_store_runner_token_key      = local.secure_parameter_store_runner_token_key
+      secure_parameter_store_runner_sentry_dsn     = local.secure_parameter_store_runner_sentry_dsn
       secure_parameter_store_region                = var.aws_region
       gitlab_runner_registration_token             = var.gitlab_runner_registration_config["registration_token"]
       giltab_runner_description                    = var.gitlab_runner_registration_config["description"]
@@ -73,6 +86,7 @@ locals {
       gitlab_runner_run_untagged                   = var.gitlab_runner_registration_config["run_untagged"]
       gitlab_runner_maximum_timeout                = var.gitlab_runner_registration_config["maximum_timeout"]
       gitlab_runner_access_level                   = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
+      sentry_dsn                                   = var.sentry_dsn
   })
 
   template_runner_config = templatefile("${path.module}/template/runner-config.tpl",
@@ -137,6 +151,7 @@ locals {
       runners_services_volumes_tmpfs    = join(",", [for v in var.runners_services_volumes_tmpfs : format("\"%s\" = \"%s\"", v.volume, v.options)])
       bucket_name                       = local.bucket_name
       shared_cache                      = var.cache_shared
+      sentry_dsn                        = var.sentry_dsn
     }
   )
 }

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -75,6 +75,16 @@ fi
 
 sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml
 
+ssm_sentry_dsn=$(aws ssm get-parameters --names "${secure_parameter_store_runner_sentry_dsn}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
+if [[ `echo ${sentry_dsn}` == "__SENTRY_DSN_REPLACED_BY_USER_DATA__" && `echo $ssm_sentry_dsn` == "null" ]]
+then
+  ssm_sentry_dsn=""
+fi
+
+# For those of you wondering why commas are used in the sed below instead of forward slashes, see https://stackoverflow.com/a/16778711/13169919
+# It is because the Sentry DSN contains forward slashes as it is an URL so it would break out of the sed command with forward slashes as delimiters :)
+sed -i.bak s,__SENTRY_DSN_REPLACED_BY_USER_DATA__,`echo $ssm_sentry_dsn`,g /etc/gitlab-runner/config.toml
+
 # A small script to remove this runner from being registered with Gitlab.
 cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration
 #!/bin/bash

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -1,5 +1,6 @@
 concurrent = ${runners_concurrent}
 check_interval = 0
+sentry_dsn = "${sentry_dsn}"
 
 [[runners]]
   name = "${runners_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -549,6 +549,12 @@ variable "secure_parameter_store_runner_token_key" {
   default     = "runner-token"
 }
 
+variable "secure_parameter_store_runner_sentry_dsn" {
+  description = "The Sentry DSN name used to store the Sentry DSN in Secure Parameter Store"
+  type        = string
+  default     = "sentry-dsn"
+}
+
 variable "enable_manage_gitlab_token" {
   description = "Boolean to enable the management of the GitLab token in SSM. If `true` the token will be stored in SSM, which means the SSM property is a terraform managed resource. If `false` the Gitlab token will be stored in the SSM by the user-data script during creation of the the instance. However the SSM parameter is not managed by terraform and will remain in SSM after a `terraform destroy`."
   type        = bool
@@ -704,4 +710,10 @@ variable "docker_machine_iam_policy_arns" {
   type        = list(string)
   description = "List of policy ARNs to be added to the instance profile of the docker machine runners."
   default     = []
+}
+
+variable "sentry_dsn" {
+  default     = "__SENTRY_DSN_REPLACED_BY_USER_DATA__"
+  description = "Sentry DSN of the project for the runner to use (uses legacy DSN format)"
+  type        = string
 }


### PR DESCRIPTION
## Description

[GitLab runners support reporting errors to Sentry](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section) which makes troubleshooting a bit easier than going through system logs.

## Migrations required

NO

## Verification

Tested in our live GitLab runners. Did not run the examples.

## Documentation

On first apply it sets the Sentry DSN to empty string which pretty much is the default behaviour. It also creates the SSM parameter in which you should set the **legacy version** of your Sentry DSN and on the next startup it will use that DSN.

Btw when I ran `pre-commit run` it gave me following output which I find kind of suspicious.

```
Terraform fmt........................................(no files to check)Skipped
Terraform validate with tflint.......................(no files to check)Skipped
Terraform docs.......................................(no files to check)Skipped
Check for merge conflicts............................(no files to check)Skipped
```
