### PR TITLE
[Proposal] Use better ressources names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -234,7 +234,7 @@ data "aws_ami" "runner" {
 }
 
 resource "aws_launch_template" "gitlab_runner_instance" {
-  name_prefix            = var.runners_name
+  name_prefix            = local.name_runner_agent_instance
   key_name               = var.ssh_key_pair
   image_id               = data.aws_ami.runner.id
   user_data              = base64encode(local.template_user_data)

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -3,7 +3,7 @@
 ########################################
 
 resource "aws_security_group" "runner" {
-  name_prefix = "${var.environment}-security-group"
+  name_prefix = "${local.name_sg}"
   vpc_id      = var.vpc_id
   description = var.gitlab_runner_security_group_description
 
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "runner_ping_group" {
 ########################################
 
 resource "aws_security_group" "docker_machine" {
-  name_prefix = "${var.environment}-docker-machine"
+  name_prefix = "${local.name_sg}-docker-machine"
   vpc_id      = var.vpc_id
   description = var.docker_machine_security_group_description
 


### PR DESCRIPTION
## Description

Launch template is named based on `runners_name`variable. It seems to be an error because this launch template is used to deploy the agent runner not docker machines. Tell me if i'm wrong.
Moreover security groups have tag `Name` with `local.name_sg`but the `name_prefix` do not use this local. Maybe it is an oversight ?

## Migrations required

NO, default values not change

## Verification

Minor changes
