### PR TITLE
Document reason for iam:PassRole

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -342,6 +342,8 @@ resource "aws_iam_role" "instance" {
 
 ################################################################################
 ### Policies for runner agent instance to create docker machines via spot req.
+###
+### iam:PassRole To pass the role from the agent to the docker machine runners
 ################################################################################
 resource "aws_iam_policy" "instance_docker_machine_policy" {
   name        = "${local.name_iam_objects}-docker-machine"


### PR DESCRIPTION
## Description

Add documentation why iam:PassRole policy is needed. See #368 

## Migrations required

no

## Verification

Comment only. No code change, no verification

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

