### PR TITLE
Updating aws_cloudwatch_log_group name to match the custom one provid…

### DIFF
--- a/logging.tf
+++ b/logging.tf
@@ -16,7 +16,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "environment" {
   count             = var.enable_cloudwatch_logging ? 1 : 0
-  name              = var.environment
+  name              = var.log_group_name != null ? var.log_group_name : var.environment
   retention_in_days = var.cloudwatch_logging_retention_in_days
   tags              = local.tags
   kms_key_id        = local.kms_key


### PR DESCRIPTION
Fix custom log_group_name usage

## Description

When you pass the log_group_name terraform input variable the expected behavior is to create this
log_group_name but it still creating the one with environment variable name.

## Migrations required

NO

## Verification

```terraform
resource "aws_cloudwatch_log_group" "environment" {
  count             = var.enable_cloudwatch_logging ? 1 : 0
  name              = var.log_group_name != null ? var.log_group_name : var.environment
  retention_in_days = var.cloudwatch_logging_retention_in_days
  tags              = local.tags
  kms_key_id        = local.kms_key
}
```

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

