### PR TITLE
Support ASG maximum instance lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ terraform destroy
 | <a name="input_docker_machine_spot_price_bid"></a> [docker\_machine\_spot\_price\_bid](#input\_docker\_machine\_spot\_price\_bid) | Spot price bid. | `string` | `"0.06"` | no |
 | <a name="input_docker_machine_version"></a> [docker\_machine\_version](#input\_docker\_machine\_version) | By default docker\_machine\_download\_url is used to set the docker machine version. Version of docker-machine. The version will be ingored once `docker_machine_download_url` is set. | `string` | `""` | no |
 | <a name="input_enable_asg_recreation"></a> [enable\_asg\_recreation](#input\_enable\_asg\_recreation) | Enable automatic redeployment of the Runner ASG when the Launch Configs change. | `bool` | `true` | no |
+| <a name="input_asg_max_instance_lifetime"></a> [asg\_max\_instance\_lifetime](#input\_asg\_max\_instance\_lifetime) | The seconds before an instance is refreshed in the ASG. | `number` | `null` | no |
 | <a name="input_enable_cloudwatch_logging"></a> [enable\_cloudwatch\_logging](#input\_enable\_cloudwatch\_logging) | Boolean used to enable or disable the CloudWatch logging. | `bool` | `true` | no |
 | <a name="input_enable_docker_machine_ssm_access"></a> [enable\_docker\_machine\_ssm\_access](#input\_enable\_docker\_machine\_ssm\_access) | Add IAM policies to the docker-machine instances to connect via the Session Manager. | `bool` | `false` | no |
 | <a name="input_enable_eip"></a> [enable\_eip](#input\_enable\_eip) | Enable the assignment of an EIP to the gitlab runner instance | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -177,9 +177,9 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   max_size                  = "1"
   desired_capacity          = "1"
   health_check_grace_period = 0
+  max_instance_lifetime     = var.asg_max_instance_lifetime
   enabled_metrics           = var.metrics_autoscaling
   tags                      = local.agent_tags_propagated
-
 
   launch_template {
     id      = aws_launch_template.gitlab_runner_instance.id

--- a/variables.tf
+++ b/variables.tf
@@ -695,6 +695,12 @@ variable "asg_delete_timeout" {
   type        = string
 }
 
+variable "asg_max_instance_lifetime" {
+  description = "The seconds before an instance is refreshed in the ASG."
+  default     = null
+  type        = number
+}
+
 variable "enable_forced_updates" {
   description = "DEPRECATED! and is replaced by `enable_asg_recreation. Setting this variable to true will do the oposite as expected. For backward compatibility the variable will remain some releases. Old desription: Enable automatic redeployment of the Runner ASG when the Launch Configs change."
   default     = null


### PR DESCRIPTION
## Description

Add a new `asg_max_instance_lifetime` input which can be used to set the
ASG maximum instance lifetime as described at
https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html.

## Migrations required

NO

## Verification

Used existing rudimentary 'default' configuration for runner deployment with the new `max_instance_lifetime` input set with success. Observed instance over several days and verified functionality worked as expected. Verified omitting the new `max_instance_lifetime` input variable applies the resources as expected.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

