### PR TITLE
Ensure the existence of overrides["name_iam_objects"] before accessing it

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -15,7 +15,7 @@ locals {
   // custom names for instances and security groups
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]
   name_sg                    = var.overrides["name_sg"] == "" ? local.tags["Name"] : var.overrides["name_sg"]
-  name_iam_objects           = var.overrides["name_iam_objects"] == "" ? local.tags["Name"] : var.overrides["name_iam_objects"]
+  name_iam_objects           = lookup(var.overrides, "name_iam_objects", "") == "" ? local.tags["Name"] : var.overrides["name_iam_objects"]
   runners_additional_volumes = <<-EOT
   %{~for volume in var.runners_additional_volumes~},"${volume}"%{endfor~}
   EOT


### PR DESCRIPTION
## Description

Get rid of the error message during `terraform apply` if `overrides["name_iam_objects"]` is not given. New keys can only be added if the `lookup(...)` function is used to access them.

Closes #363 

## Migrations required

No.

## Verification

No verification done.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

