### PR TITLE
feat!: Add variable for Docker registry mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ terraform destroy
 | <a name="input_runners_gitlab_url"></a> [runners\_gitlab\_url](#input\_runners\_gitlab\_url) | URL of the GitLab instance to connect to. | `string` | n/a | yes |
 | <a name="input_runners_helper_image"></a> [runners\_helper\_image](#input\_runners\_helper\_image) | Overrides the default helper image used to clone repos and upload artifacts, will be used in the runner config.toml | `string` | `""` | no |
 | <a name="input_runners_iam_instance_profile_name"></a> [runners\_iam\_instance\_profile\_name](#input\_runners\_iam\_instance\_profile\_name) | IAM instance profile name of the runners, will be used in the runner config.toml | `string` | `""` | no |
+| <a name="input_runners_docker_registry_mirror"></a> [runners\_docker\_registry\_mirror](#input\_runners\_docker\_registry\_mirror) | The docker registry mirror to use to avoid rate limiting by hub.docker.com | `string` | `""` | no |
 | <a name="input_runners_idle_count"></a> [runners\_idle\_count](#input\_runners\_idle\_count) | Idle count of the runners, will be used in the runner config.toml. | `number` | `0` | no |
 | <a name="input_runners_idle_time"></a> [runners\_idle\_time](#input\_runners\_idle\_time) | Idle time of the runners, will be used in the runner config.toml. | `number` | `600` | no |
 | <a name="input_runners_image"></a> [runners\_image](#input\_runners\_image) | Image to run builds, will be used in the runner config.toml | `string` | `"docker:18.03.1-ce"` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -2,10 +2,10 @@ locals {
   // Convert list to a string separated and prepend by a comma
   docker_machine_options_string = format(
     ",%s",
-    join(",", formatlist("%q", concat(var.docker_machine_options, [local.runners_docker_registry_mirror_option]))),
+    join(",", formatlist("%q", concat(var.docker_machine_options, local.runners_docker_registry_mirror_option))),
   )
 
-  runners_docker_registry_mirror_option = var.runners_docker_registry_mirror == "" ? "" : "engine-registry-mirror=${var.runners_docker_registry_mirror}"
+  runners_docker_registry_mirror_option = var.runners_docker_registry_mirror == "" ? [] : ["engine-registry-mirror=${var.runners_docker_registry_mirror}"]
 
   // Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)

--- a/locals.tf
+++ b/locals.tf
@@ -2,8 +2,10 @@ locals {
   // Convert list to a string separated and prepend by a comma
   docker_machine_options_string = format(
     ",%s",
-    join(",", formatlist("%q", var.docker_machine_options)),
+    join(",", formatlist("%q", concat(var.docker_machine_options, [local.runners_docker_registry_mirror_option]))),
   )
+
+  runners_docker_registry_mirror_option = var.runners_docker_registry_mirror == "" ? "" : "engine-registry-mirror=${var.runners_docker_registry_mirror}"
 
   // Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ locals {
       runners_ebs_optimized       = var.runners_ebs_optimized
       runners_instance_profile    = aws_iam_instance_profile.docker_machine.name
       runners_additional_volumes  = local.runners_additional_volumes
-      docker_machine_options      = length(var.docker_machine_options) == 0 ? "" : local.docker_machine_options_string
+      docker_machine_options      = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
       runners_name                = var.runners_name
       runners_tags = replace(var.overrides["name_docker_machine_runners"] == "" ? format(
         "Name,%s-docker-machine,%s,%s",

--- a/variables.tf
+++ b/variables.tf
@@ -278,6 +278,12 @@ variable "runners_iam_instance_profile_name" {
   default     = ""
 }
 
+variable "runners_docker_registry_mirror" {
+  description = "The docker registry mirror to use to avoid rate limiting by hub.docker.com"
+  type        = string
+  default     = ""
+}
+
 variable "runners_environment_vars" {
   description = "Environment variables during build execution, e.g. KEY=Value, see runner-public example. Will be used in the runner config.toml"
   type        = list(string)


### PR DESCRIPTION
## Description

As [Docker](https://docs.docker.com/docker-hub/download-rate-limit/) introduced rate limiting we should set a Docker registry mirror. This was possible via `docker_machine_options`. I think it makes sense to make this explicit using a dedicated variable.

Solves a part of #393 
Closes #270 

## Migrations required

Yes, if the option `engine-registry-mirror` is used within the `docker_machine_options`. If so move the mirror URL to the new variable `runners_docker_registry_mirror`

## Verification

Checked all combinations of `runners_docker_registry_mirror` and `docker_machine_options`.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

