### PR TITLE
Remove runner agents if provider assumed a role

### DIFF
--- a/bin/remove-runner.sh
+++ b/bin/remove-runner.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-set -e
-
-TOKEN=$(aws ssm get-parameters --name $3 --with-decryption --region $1 | jq -r ".Parameters | .[0] | .Value")
-curl -sS --request DELETE "${2}/api/v4/runners" --form "token=${TOKEN}"

--- a/main.tf
+++ b/main.tf
@@ -21,13 +21,20 @@ resource "aws_ssm_parameter" "runner_registration_token" {
   }
 }
 
+# to read the current token for the null_resource. aws_ssm_parameter.runner_registration_token.value is never updated!
+data "aws_ssm_parameter" "current_runner_registration_token" {
+  depends_on = [aws_ssm_parameter.runner_registration_token]
+
+  name = local.secure_parameter_store_runner_token_key
+}
+
 resource "null_resource" "remove_runner" {
   depends_on = [aws_ssm_parameter.runner_registration_token]
 
   triggers = {
     aws_region                = var.aws_region
     runners_gitlab_url        = var.runners_gitlab_url
-    runner_registration_token = aws_ssm_parameter.runner_registration_token.value
+    runner_registration_token = data.aws_ssm_parameter.current_runner_registration_token.value
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -27,13 +27,13 @@ resource "null_resource" "remove_runner" {
   triggers = {
     aws_region                              = var.aws_region
     runners_gitlab_url                      = var.runners_gitlab_url
-    secure_parameter_store_runner_token_key = local.secure_parameter_store_runner_token_key
+    runner_registration_token               = aws_ssm_parameter.runner_registration_token.value
   }
 
   provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    command    = "curl -sS --request DELETE \"${var.runners_gitlab_url}/api/v4/runners\" --form \"token=${aws_ssm_parameter.runner_registration_token.value}\""
+    command    = "curl -sS --request DELETE \"${self.triggers.runners_gitlab_url}/api/v4/runners\" --form \"token=${self.triggers.runner_registration_token}\""
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -25,9 +25,9 @@ resource "null_resource" "remove_runner" {
   depends_on = [aws_ssm_parameter.runner_registration_token]
 
   triggers = {
-    aws_region                              = var.aws_region
-    runners_gitlab_url                      = var.runners_gitlab_url
-    runner_registration_token               = aws_ssm_parameter.runner_registration_token.value
+    aws_region                = var.aws_region
+    runners_gitlab_url        = var.runners_gitlab_url
+    runner_registration_token = aws_ssm_parameter.runner_registration_token.value
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ resource "aws_ssm_parameter" "runner_registration_token" {
 
 resource "null_resource" "remove_runner" {
   depends_on = [aws_ssm_parameter.runner_registration_token]
+
   triggers = {
-    script                                  = "${path.module}/bin/remove-runner.sh"
     aws_region                              = var.aws_region
     runners_gitlab_url                      = var.runners_gitlab_url
     secure_parameter_store_runner_token_key = local.secure_parameter_store_runner_token_key
@@ -33,7 +33,7 @@ resource "null_resource" "remove_runner" {
   provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    command    = "${self.triggers.script} ${self.triggers.aws_region} ${self.triggers.runners_gitlab_url} ${self.triggers.secure_parameter_store_runner_token_key}"
+    command    = "curl -sS --request DELETE \"${var.runners_gitlab_url}/api/v4/runners\" --form \"token=${aws_ssm_parameter.runner_registration_token.value}\""
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_version = ">= 0.13.0"
+
   required_providers {
     aws = {
       version = ">= 3.35.0"
       source  = "hashicorp/aws"
     }
+
     null = {
       source = "hashicorp/null"
     }


### PR DESCRIPTION
## Description

If the AWS provider assumes a role, it is not possible to use the AWS CLI to interact with the cloud resources as the CLI does not assume the role automatically. The removal of the runner agents from Gitlab fails.

This PR moves the whole script to remove the runner agent into the Terraform code and does not use the AWS CLI.

Closes #371 

## Migrations required

No

## Verification

Still pending.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

