### PR TITLE
refactor!: Reword the `subnet_id_runners` to reflect that the executors are meant

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ module "runner" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.private_subnets
-  subnet_id_runners        = element(module.vpc.private_subnets, 0)
+  subnet_id_executors      = element(module.vpc.private_subnets, 0)
 
   runners_name       = "docker-default"
   runners_gitlab_url = "https://gitlab.com"
@@ -424,7 +424,7 @@ terraform destroy
 | <a name="input_secure_parameter_store_runner_sentry_dsn"></a> [secure\_parameter\_store\_runner\_sentry\_dsn](#input\_secure\_parameter\_store\_runner\_sentry\_dsn) | The Sentry DSN name used to store the Sentry DSN in Secure Parameter Store | `string` | `"sentry-dsn"` | no |
 | <a name="input_secure_parameter_store_runner_token_key"></a> [secure\_parameter\_store\_runner\_token\_key](#input\_secure\_parameter\_store\_runner\_token\_key) | The key name used store the Gitlab runner token in Secure Parameter Store | `string` | `"runner-token"` | no |
 | <a name="input_sentry_dsn"></a> [sentry\_dsn](#input\_sentry\_dsn) | Sentry DSN of the project for the runner to use (uses legacy DSN format) | `string` | `"__SENTRY_DSN_REPLACED_BY_USER_DATA__"` | no |
-| <a name="input_subnet_id_runners"></a> [subnet\_id\_runners](#input\_subnet\_id\_runners) | List of subnets used for hosting the gitlab-runners. | `string` | n/a | yes |
+| <a name="input_subnet_id_executors"></a> [subnet\_id\_executors](#input\_subnet\_id\_executors) | Subnet id used to host the executors. | `string` | n/a | yes |
 | <a name="input_subnet_ids_gitlab_runner"></a> [subnet\_ids\_gitlab\_runner](#input\_subnet\_ids\_gitlab\_runner) | Subnet used for hosting the GitLab runner. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |
 | <a name="input_userdata_post_install"></a> [userdata\_post\_install](#input\_userdata\_post\_install) | User-data script snippet to insert after GitLab runner install | `string` | `""` | no |

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -35,7 +35,7 @@ module "runner" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.private_subnets
-  subnet_id_runners        = element(module.vpc.private_subnets, 0)
+  subnet_id_executors      = element(module.vpc.private_subnets, 0)
   metrics_autoscaling      = ["GroupDesiredCapacity", "GroupInServiceCapacity"]
 
   runners_name             = var.runner_name

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -33,7 +33,7 @@ module "runner" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.public_subnets
-  subnet_id_runners        = element(module.vpc.public_subnets, 0)
+  subnet_id_executors      = element(module.vpc.public_subnets, 0)
 
   runners_executor   = "docker"
   runners_name       = var.runner_name

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -31,7 +31,7 @@ module "runner" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.private_subnets
-  subnet_id_runners        = element(module.vpc.private_subnets, 0)
+  subnet_id_executors      = element(module.vpc.private_subnets, 0)
 
   runners_name       = var.runner_name
   runners_gitlab_url = var.gitlab_url

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -34,7 +34,7 @@ module "runner" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.public_subnets
-  subnet_id_runners        = element(module.vpc.public_subnets, 0)
+  subnet_id_executors      = element(module.vpc.public_subnets, 0)
 
   docker_machine_spot_price_bid = "on-demand-price"
 
@@ -80,7 +80,7 @@ module "runner2" {
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids_gitlab_runner = module.vpc.public_subnets
-  subnet_id_runners        = element(module.vpc.public_subnets, 0)
+  subnet_id_executors      = element(module.vpc.public_subnets, 0)
 
   docker_machine_spot_price_bid = "on-demand-price"
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_subnet" "runners" {
-  id = var.subnet_id_runners
+data "aws_subnet" "executors" {
+  id = var.subnet_id_executors
 }
 
-data "aws_availability_zone" "runners" {
-  name = data.aws_subnet.runners.availability_zone
+data "aws_availability_zone" "executors" {
+  name = data.aws_subnet.executors.availability_zone
 }
 
 # Parameter value is managed by the user-data script of the gitlab runner instance
@@ -99,8 +99,8 @@ locals {
       aws_region                  = var.aws_region
       gitlab_url                  = var.runners_gitlab_url
       runners_vpc_id              = var.vpc_id
-      runners_subnet_id           = var.subnet_id_runners
-      runners_aws_zone            = data.aws_availability_zone.runners.name_suffix
+      runners_subnet_id           = var.subnet_id_executors
+      runners_aws_zone            = data.aws_availability_zone.executors.name_suffix
       runners_instance_type       = var.docker_machine_instance_type
       runners_spot_price_bid      = var.docker_machine_spot_price_bid == "on-demand-price" ? "" : var.docker_machine_spot_price_bid
       runners_ami                 = data.aws_ami.docker-machine.id

--- a/variables.tf
+++ b/variables.tf
@@ -29,8 +29,8 @@ variable "subnet_ids_gitlab_runner" {
   type        = list(string)
 }
 
-variable "extra_security_group_ids_runner" {
-  description = "Optional IDs of extra security groups to apply to the runner. This will not apply to the runner instances spun up when using the docker+machine executor, which is the default."
+variable "extra_security_group_ids_runner_agent" {
+  description = "Optional IDs of extra security groups to apply to the runner agent. This will not apply to the runners spun up when using the docker+machine executor, which is the default."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,8 +19,8 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "subnet_id_runners" {
-  description = "List of subnets used for hosting the gitlab-runners."
+variable "subnet_id_executors" {
+  description = "Subnet id used to host the executors."
   type        = string
 }
 
@@ -29,8 +29,8 @@ variable "subnet_ids_gitlab_runner" {
   type        = list(string)
 }
 
-variable "extra_security_group_ids_runner_agent" {
-  description = "Optional IDs of extra security groups to apply to the runner agent. This will not apply to the runners spun up when using the docker+machine executor, which is the default."
+variable "extra_security_group_ids_runner" {
+  description = "Optional IDs of extra security groups to apply to the runner. This will not apply to the runner instances spun up when using the docker+machine executor, which is the default."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Description

Renames the `subnet_id_runners` to `subnet_id_executors` to follow the naming conventions at Gitlab.

Solves part of #405 

## Migrations required

Rename `subnet_id_runners` to `subnet_id_executors`.

## Verification

Ran a `terraform plan`. Terraform wants to update the launch templates and auto scaling groups and replace the null resource. I do not fully understand why this is necessary.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

