### PR TITLE
Attach cache bucket policy to docker machine instance role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -403,7 +403,7 @@ resource "aws_iam_role_policy_attachment" "user_defined_policies" {
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
   count      = var.cache_bucket["create"] || lookup(var.cache_bucket, "policy", "") != "" ? 1 : 0
-  role       = aws_iam_role.instance.name
+  role       = aws_iam_role.docker_machine.name
   policy_arn = local.bucket_policy
 }
 


### PR DESCRIPTION
## Description

The cache bucket policy is attached to the runner instance role by default but should be attached to the docker machine instance role instead.

## Migrations required

NO

## Verification

Verified that this works with a simple docker+machine runner configuration and cache creation.