### PR TITLE
Add launch template name to module outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ terraform destroy
 | <a name="output_runner_cache_bucket_arn"></a> [runner\_cache\_bucket\_arn](#output\_runner\_cache\_bucket\_arn) | ARN of the S3 for the build cache. |
 | <a name="output_runner_cache_bucket_name"></a> [runner\_cache\_bucket\_name](#output\_runner\_cache\_bucket\_name) | Name of the S3 for the build cache. |
 | <a name="output_runner_eip"></a> [runner\_eip](#output\_runner\_eip) | EIP of the Gitlab Runner |
+| <a name="output_runner_launch_template_name"></a> [runner\_launch\_template\_name](#output\_runner\_launch\_template\_name) | The name of the runner's launch template. |
 | <a name="output_runner_role_arn"></a> [runner\_role\_arn](#output\_runner\_role\_arn) | ARN of the role used for the docker machine runners. |
 | <a name="output_runner_role_name"></a> [runner\_role\_name](#output\_runner\_role\_name) | Name of the role used for the docker machine runners. |
 | <a name="output_runner_sg_id"></a> [runner\_sg\_id](#output\_runner\_sg\_id) | ID of the security group attached to the docker machine runners. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,8 @@ output "runner_eip" {
   description = "EIP of the Gitlab Runner"
   value       = element(concat(aws_eip.gitlab_runner.*.public_ip, [""]), 0)
 }
+
+output "runner_launch_template_name" {
+  description = "The name of the runner's launch template."
+  value       = aws_launch_template.gitlab_runner_instance.name
+}


### PR DESCRIPTION
## Description

Add a `runner_launch_template_name` output to the module to return the
name of the launch template that's managed.

## Migrations required

NO

## Verification

Base example; my own existing deployment

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

