### PR TITLE
Removed extra backticks.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
         encrypted             = lookup(block_device_mappings.value, "encrypted", true)
         iops                  = lookup(block_device_mappings.value, "iops", null)
         throughput            = lookup(block_device_mappings.value, "throughput", null)
-        kms_key_id            = lookup(block_device_mappings.value, "`kms_key_id`", null)
+        kms_key_id            = lookup(block_device_mappings.value, "kms_key_id", null)
       }
     }
   }


### PR DESCRIPTION
## Description

The documentation references being able to use "kms_key_id" in a dictionary in order to be able to encrypt the EBS volume.  This did not work, and the actual value was \`kms_key_id\`.  Corrected that.

## Migrations required

NO

## Verification

Modified locally and ran - the ARN was successfully found and updated.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

