### PR TITLE
feat: Request new Runner token if invalid

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -64,7 +64,7 @@ token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_ke
 valid_token=true
 if [[ `echo $token` != "null" ]]
 then
-  valid_token_response=$(curl -s -o /dev/null -w "%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=${token}" )
+  valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=${token}" )
   [[ `echo $valid_token_response` != "200" ]] && valid_token=false
 fi
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -64,7 +64,7 @@ token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_ke
 valid_token=true
 if [[ `echo $token` != "null" ]]
 then
-  valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=${token}" )
+  valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
   [[ `echo $valid_token_response` != "200" ]] && valid_token=false
 fi
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -58,8 +58,17 @@ if ! [ -x "$(command -v jq)" ]; then
   yum install jq -y
 fi
 
+# fetch Runner token from SSM and validate it
 token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
-if [[ `echo ${runners_token}` == "__REPLACED_BY_USER_DATA__" && `echo $token` == "null" ]]
+
+valid_token=true
+if [[ `echo $token` != "null" ]]
+then
+  valid_token_response=$(curl -s -o /dev/null -w "%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=${token}" )
+  [[ `echo $valid_token_response` != "200" ]] && valid_token=false
+fi
+
+if [[ `echo ${runners_token}` == "__REPLACED_BY_USER_DATA__" && `echo $token` == "null" ]] || [[ `echo $valid_token` == "false" ]]
 then
   token=$(curl --request POST -L "${runners_gitlab_url}/api/v4/runners" \
     --form "token=${gitlab_runner_registration_token}" \


### PR DESCRIPTION
## Description

This PR is based on the work of patramsey as described in #230.

Gitlab Runner checks the validity of the token stored in SSM. In case the token is invalid a new one is requested.

Closes #230 

## Migrations required

No

## Verification

The following verifications were done:
- Change the registration token manually, kill the Runner manually. I expect to get a new Runner registered at Gitlab. Success.
- Delete the Gitlab Runner from Gitlab and kill the Runner EC2. Expect to get a newly registered Runner. Success.
- Check Cloudwatch logs to see the result of the verification call: 403. Success.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

