### PR TITLE
build: Format Terraform files recursively

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
     rev: v1.55.0
     hooks:
       - id: terraform_fmt
+        args:
+          - --args=-recursive
       - id: terraform_tflint
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Description

Add the `-recursive` argument to `terraform fmt` to format all files in this repository.

Fixes part of #423

## Migrations required

No

## Verification

Ran pre-commit and verified that the files were formatted.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

