### PR TITLE
Switch logging to JSON

### DIFF
--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -1,6 +1,7 @@
 concurrent = ${runners_concurrent}
 check_interval = ${runners_check_interval}
 sentry_dsn = "${sentry_dsn}"
+log_format = "json"
 
 [[runners]]
   name = "${runners_name}"


### PR DESCRIPTION
## Description

Gitlab runner uses text-based logging by default. However due to https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/179 all of the logs include tty coloring codes which make logs pain to process or read.

Since this module offers logging to cloudwatch by default anyways this simple change will make the log readable and usable in CloudWatch.

## Migrations required

NO. Will be handled by Gitlab runner instance refresh.

## Verification

Changed manually on the server. Then tried this change in my environment.

## Documentation

No changes needed.

