### PR TITLE
fix: Pin AWS provider to 3.x since 4.x provider has breaking S3 changes

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 3.35.0"
+      version = ">= 3.35.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
 


### PR DESCRIPTION
## Description
The new v4.0 of the AWS provider refactored how S3 bucket resources are defined and are breaking changes. Until the `cache` internal module is refactored to use the newer S3 resources (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor) the provider should probably be pinned to avoid compatibility issues.

### Example
Even though we created our own S3 buckets and passed that in to the gitlab runner config, the fact that the `cache` module uses the old resource variables caused issues during evaluation.

<img width="1375" alt="Terraform Cloud error" src="https://user-images.githubusercontent.com/1537017/153956134-153ec9b8-8c01-47b9-8c6f-944911c22a73.png">


## Migrations required

NO

## Verification

No verifications done as we are only pinning the provider version upper bound.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

