### PR TITLE
refactor: Terraform AWS Provider Version 4 Upgrade

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -27,36 +27,55 @@ resource "aws_s3_bucket" "build_cache" {
   count = var.create_cache_bucket ? 1 : 0
 
   bucket = local.cache_bucket_name
-  acl    = "private"
 
   tags = local.tags
 
   force_destroy = true
 
-  versioning {
-    enabled = var.cache_bucket_versioning
+}
+
+resource "aws_s3_bucket_acl" "build_cache_acl" {
+  count  = var.create_cache_bucket ? 1 : 0
+  bucket = aws_s3_bucket.build_cache[0].id
+
+  acl = "private"
+}
+
+resource "aws_s3_bucket_versioning" "build_cache_versioning" {
+  count  = var.create_cache_bucket ? 1 : 0
+  bucket = aws_s3_bucket.build_cache[0].id
+
+  versioning_configuration {
+    status = var.cache_bucket_versioning ? "Enabled" : "Suspended"
   }
+}
 
-  lifecycle_rule {
-    id      = "clear"
-    enabled = var.cache_lifecycle_clear
+resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
+  count  = var.create_cache_bucket ? 1 : 0
+  bucket = aws_s3_bucket.build_cache[0].id
 
-    prefix = var.cache_lifecycle_prefix
+  rule {
+    id     = "clear"
+    status = var.cache_lifecycle_clear ? "Enabled" : "Disabled"
+
+    filter {
+      prefix = var.cache_lifecycle_prefix
+    }
 
     expiration {
       days = var.cache_expiration_days
-    }
-
-    noncurrent_version_expiration {
-      days = var.cache_expiration_days
+      expired_object_delete_marker = var.cache_expiration_days > 0 ? true : false
     }
   }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "build_cache_encryption" {
+  count  = var.create_cache_bucket ? 1 : 0
+  bucket = aws_s3_bucket.build_cache[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -23,8 +23,8 @@ variable "cache_bucket_name_include_account_id" {
 
 variable "cache_bucket_versioning" {
   description = "Boolean used to enable versioning on the cache bucket, false by default."
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "cache_expiration_days" {

--- a/modules/cache/versions.tf
+++ b/modules/cache/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      version = ">= 4.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
Followed upgrade guide according to:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor

## Description

Update to version 4 of the AWS provider


