### PR TITLE
feat: Skip runner download and install if already installed

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -28,8 +28,11 @@ then
   yum install amazon-ecr-credential-helper -y
 fi
 
-curl --fail --retry 6 -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash
-yum install gitlab-runner-${gitlab_runner_version} -y
+if ! ( rpm -q gitlab-runner >/dev/null )
+then
+  curl --fail --retry 6 -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash
+  yum install gitlab-runner-${gitlab_runner_version} -y
+fi
 
 if [[ `echo ${docker_machine_download_url}` == "" ]]
 then


### PR DESCRIPTION
## Description

Currently the gitlab runner user data will try to download/run install script then install. This change will allow alternative installation via userdata_pre_install

## Migrations required

NO

## Verification

Tested without issue using default install and when already installed. 

## Documentation

pre-commit run fine, no change to terraform inputs or docs required.

