### PR TITLE
fix: bump gitlab-runner version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -361,7 +361,7 @@ variable "cache_shared" {
 variable "gitlab_runner_version" {
   description = "Version of the [GitLab runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases)."
   type        = string
-  default     = "14.8.2"
+  default     = "14.9.1"
 }
 
 variable "enable_ping" {


### PR DESCRIPTION
## Description

It seems that the current gitlab-runner version is not available anymore in the yum repo. This PR bumps the gitlab runner version to install a supported runner version.

Related `journalctl` output:

```
Apr 06 12:20:01 ip-10-0-1-209.ec2.internal systemd[1]: Removed slice User Slice of root.
Apr 06 12:20:01 ip-10-0-1-209.ec2.internal user-data[2442]: Generating yum cache for runner_gitlab-runner...
Apr 06 12:20:02 ip-10-0-1-209.ec2.internal user-data[2442]: Importing GPG key 0x51312F3F:
Apr 06 12:20:02 ip-10-0-1-209.ec2.internal user-data[2442]:  Userid     : "GitLab B.V. (package repository signing key) <packages@gitlab.com>"
Apr 06 12:20:02 ip-10-0-1-209.ec2.internal user-data[2442]:  Fingerprint: f640 3f65 44a3 8863 daa0 b6e0 3f01 618a 5131 2f3f
Apr 06 12:20:02 ip-10-0-1-209.ec2.internal user-data[2442]:  From       : https://packages.gitlab.com/runner/gitlab-runner/gpgkey
Apr 06 12:20:03 ip-10-0-1-209.ec2.internal user-data[2442]: Generating yum cache for runner_gitlab-runner-source...
Apr 06 12:20:04 ip-10-0-1-209.ec2.internal user-data[2442]:
Apr 06 12:20:05 ip-10-0-1-209.ec2.internal user-data[2442]: The repository is setup! You can now install packages.
Apr 06 12:20:05 ip-10-0-1-209.ec2.internal user-data[2442]: + yum install gitlab-runner-14.8.0 -y
Apr 06 12:20:05 ip-10-0-1-209.ec2.internal user-data[2442]: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Apr 06 12:20:06 ip-10-0-1-209.ec2.internal user-data[2442]: No package gitlab-runner-14.8.0 available.
```

## Migrations required

NO

## Verification

1. Spin up a new EC2 instance with the given parameters
2. Run `yum list available gitlab-runner`
3. Validate that the only available package is `gitlab-runner 14.9.1-1`

Instance parameters:

```
         Icon name: computer-vm
           Chassis: vm
        Machine ID: ec241e799eaf2c0ee222f87da91ab53c
           Boot ID: 3207bc93419547769999e283ef57de2b
    Virtualization: amazon
  Operating System: Amazon Linux 2
       CPE OS Name: cpe:2.3:o:amazon:amazon_linux:2
            Kernel: Linux 4.14.268-205.500.amzn2.x86_64
      Architecture: x86-64
```

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

