### PR TITLE
fix: terminate lambda: don't specify architecture

### DIFF
--- a/modules/terminate-instances/main.tf
+++ b/modules/terminate-instances/main.tf
@@ -17,7 +17,6 @@ data "archive_file" "terminate_runner_instances_lambda" {
 }
 
 resource "aws_lambda_function" "terminate_runner_instances" {
-  architectures    = ["x86_64"]
   description      = "Lifecycle hook for terminating GitLab runner instances"
   filename         = data.archive_file.terminate_runner_instances_lambda.output_path
   source_code_hash = data.archive_file.terminate_runner_instances_lambda.output_base64sha256


### PR DESCRIPTION
## Description

https://github.com/npalm/terraform-aws-gitlab-runner/issues/464 reports that the `architectures` argument was added in the AWS provider 3.61.0 and this module specifies 3.35 as a minimum.

The `architectures` argument is optional and defaults to 'x86_64' anyway.

This removes it so that it's compatible with the older AWS provider.)

## Migrations required

NO

## Verification

Verified using the _runner-default_ example

## Documentation

N/A
