### PR TITLE
471 add AuthenticationType

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ locals {
       bucket_name                       = local.bucket_name
       shared_cache                      = var.cache_shared
       sentry_dsn                        = var.sentry_dsn
+      gitlab_runner_major_version       = tonumber(split(".", var.gitlab_runner_version)[0])
     }
   )
 }

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -37,6 +37,8 @@ log_format = "json"
       BucketName = "${bucket_name}"
       BucketLocation = "${aws_region}"
       Insecure = false
+%{ if gitlab_runner_major_version >= 15 }      AuthenticationType = "IAM"
+%{ endif ~}
   [runners.machine]
     IdleCount = ${runners_idle_count}
     IdleTime = ${runners_idle_time}


### PR DESCRIPTION
## Description

One method to support adding AuthenticationType = "IAM" whilst ensuring no changes to configuration for earlier versions.
Only adds it in if the major version of the runner is 15 or higher.

## Migrations required

NO

## Verification

Tested with versions 14 & 15 to confirm the user-data only sees this change if version 15.


