### PR TITLE
fix: Use dynamic block to avoid endless churn on spot_options block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -226,8 +226,11 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     for_each = var.runner_instance_spot_price == null || var.runner_instance_spot_price == "" ? [] : ["spot"]
     content {
       market_type = instance_market_options.value
-      spot_options {
-        max_price = var.runner_instance_spot_price == "on-demand-price" ? "" : var.runner_instance_spot_price
+      dynamic "spot_options" {
+        for_each = var.runner_instance_spot_price == "on-demand-price" ? [] : [0]
+        content {
+            max_price = var.runner_instance_spot_price
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

We use on-demand-price and recently upgraded from 4.35 to 4.41.1. On every run we see:

```
      ~ instance_market_options {
            # (1 unchanged attribute hidden)

          + spot_options {}
        }
```
... causing a complete rebuild. This fixes that problem with a dynamic block on `spot_options`

## Migrations required

NO

## Verification

I verified using runner_instance_spot_price    = "on-demand-price" and "0.18". Both work as expected.

## Documentation

None.