### PR TITLE
fix: join the docker volumes with \n instead of ,

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.64.1
     hooks:
       - id: terraform_fmt
         args:
           - --args=-recursive
       - id: terraform_tflint
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
       - id: check-merge-conflict

--- a/main.tf
+++ b/main.tf
@@ -126,8 +126,8 @@ locals {
       runners_request_concurrency       = var.runners_request_concurrency
       runners_output_limit              = var.runners_output_limit
       runners_check_interval            = var.runners_check_interval
-      runners_volumes_tmpfs             = join(",", [for v in var.runners_volumes_tmpfs : format("\"%s\" = \"%s\"", v.volume, v.options)])
-      runners_services_volumes_tmpfs    = join(",", [for v in var.runners_services_volumes_tmpfs : format("\"%s\" = \"%s\"", v.volume, v.options)])
+      runners_volumes_tmpfs             = join("\n", [for v in var.runners_volumes_tmpfs : format("\"%s\" = \"%s\"", v.volume, v.options)])
+      runners_services_volumes_tmpfs    = join("\n", [for v in var.runners_services_volumes_tmpfs : format("\"%s\" = \"%s\"", v.volume, v.options)])
       bucket_name                       = local.bucket_name
       shared_cache                      = var.cache_shared
       sentry_dsn                        = var.sentry_dsn


### PR DESCRIPTION
## Description

Join the Docker tmpfs volumes in the `runner-config.tpl` with a newline character instead of `,`. This gives the correct syntax as explained in the mentioned issue.

```
[runners.docker.services_tmpfs]
"/var/lib/mysql/" = "rw,noexec","/var/lib/postgresql/data" = "rw,noexec"
```

Closes #479 

## Migrations required

No

## Verification

Checked the plan for multiple volumes.

