### PR TITLE
chore: switch to https for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.64.1
     hooks:
       - id: terraform_fmt
         args:
           - --args=-recursive
       - id: terraform_tflint
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
       - id: check-merge-conflict


### PR DESCRIPTION
## Description

`pre-commit` fails with `The unauthenticated git protocol on port 9418 is no longer supported`. Switch to https to fix that.

## Migrations required

No

## Verification

Run `pre-commit`.