### PR TITLE
chore: git ignore `builds/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ config-terraform.sh
 package*.json
 yarn.lock
 
+builds/
+
 # exceptions for semantic release
 !.release/package*
 !.release/*.lock


### PR DESCRIPTION
## Description

Ignore the `builds/` directory which contains the zipped AWS Lambda function. Add the directory to the `.gitignore` to make sure it is not checked in by accident.

## Migrations required

No

## Verification

None