### PR TITLE
Add AuthenticationType for [runners.cache.s3]

### DIFF
--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -33,6 +33,7 @@ log_format = "json"
     Type = "s3"
     Shared = ${shared_cache}
     [runners.cache.s3]
+      AuthenticationType = "${auth_type}"
       ServerAddress = "s3.amazonaws.com"
       BucketName = "${bucket_name}"
       BucketLocation = "${aws_region}"

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,8 @@ variable "arn_format" {
 
 variable "auth_type" {
   description = "A string that declares the AuthenticationType for [runners.cache.s3]. Can either be 'iam' or 'credentials'"
-  type        = strings
-  default = "iam"
+  type        = string
+  default     = "iam"
 }
 
 variable "environment" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "arn_format" {
   description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions."
 }
 
+variable "auth_type" {
+  description = "A string that declares the AuthenticationType for [runners.cache.s3]. Can either be 'iam' or 'credentials'"
+  type        = string
+}
+
 variable "environment" {
   description = "A name that identifies the environment, used as prefix and for tagging."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,8 @@ variable "arn_format" {
 
 variable "auth_type" {
   description = "A string that declares the AuthenticationType for [runners.cache.s3]. Can either be 'iam' or 'credentials'"
-  type        = string
+  type        = strings
+  default = "iam"
 }
 
 variable "environment" {


### PR DESCRIPTION
## Description
This PR adds the AuthenticationType for [runners.cache.s3]. Not specifying an AuthenticationType is a [deprecated](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28171) feature and breaking change for GitLab 15.0.

The AuthenticationType can either be `iam` or `credentials`, and this PR allows the user to specify which AuthenticationType they use as a variable. Previously, this would default to iam credentials, so I maintained the default authentication method in `variables.tf`

## Migrations required

No

## Verification

When the runner was manually updated, the change only impacts the actual launch template of the child runners. All future spawns will be using the correct auth type.
