### PR TITLE
Fix typo

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "runner_instance_metadata_options_http_endpoint" {
 }
 
 variable "runner_instance_metadata_options_http_tokens" {
-  description = "EPRECATED, replaced by runner_instance_metadata_options. Set if Gitlab runner agent instance metadata service session tokens are required. The allowed values are optional, required."
+  description = "DEPRECATED, replaced by runner_instance_metadata_options. Set if Gitlab runner agent instance metadata service session tokens are required. The allowed values are optional, required."
   type        = string
   default     = null
 


### PR DESCRIPTION

## Description

- Just fix typo in `runner_instance_metadata_options_http_tokens` description.

## Migrations required

NO

## Verification

Please mention the examples you have verified.

## Documentation

We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.

