### PR TITLE
Make statement IDs unique

### DIFF
--- a/modules/terminate-instances/main.tf
+++ b/modules/terminate-instances/main.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_permission" "current_version_triggers" {
 
 resource "aws_lambda_permission" "unqualified_alias_triggers" {
   function_name = aws_lambda_function.terminate_runner_instances.function_name
-  statement_id  = "TerminateInstanceEvent"
+  statement_id  = "TerminateInstanceEventUnqualified"
   action        = "lambda:InvokeFunction"
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.terminate_instances.arn


### PR DESCRIPTION
## Description

Somehow the lambda permissions in the "terminate-instances" module have identical statement IDs and somehow this was fine until I tried to migrate my runner infrastructure to a different Terraform configuration.

## Migrations required

No migrations required.

## Verification

This has been verified on my production environment, which is a slightly tweaked version of the "runner-docker" example.