### PR TITLE
ci: remove TfDocs from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,3 @@ YES | NO - If yes please describe the migration.
 
 Please mention the examples you have verified.
 
-## Documentation
-
-We use [pre-commit](https://pre-commit.com/) to update the Terraform inputs and outputs in the documentation via [terraform-docs](https://github.com/terraform-docs/terraform-docs). Ensure you have installed those components.
-


### PR DESCRIPTION
## Description

Removes the TfDocs section from the pull request template as the docs are updated automatically in the pipeline. So this comment is no longer needed. See #495 

## Migrations required

No

## Verification

No verification done.

