### PR TITLE
feat: add `clone_url` to `config.toml`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ locals {
     {
       aws_region                  = var.aws_region
       gitlab_url                  = var.runners_gitlab_url
-      clone_url                   = var.runners_clone_url
+      gitlab_clone_url            = var.runners_clone_url
       runners_vpc_id              = var.vpc_id
       runners_subnet_id           = length(var.subnet_id) > 0 ? var.subnet_id : var.subnet_id_runners
       runners_aws_zone            = data.aws_availability_zone.runners.name_suffix

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ locals {
     {
       aws_region                  = var.aws_region
       gitlab_url                  = var.runners_gitlab_url
+      clone_url                   = var.runners_clone_url
       runners_vpc_id              = var.vpc_id
       runners_subnet_id           = length(var.subnet_id) > 0 ? var.subnet_id : var.subnet_id_runners
       runners_aws_zone            = data.aws_availability_zone.runners.name_suffix

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -7,6 +7,7 @@ listen_address = "${prometheus_listen_address}"
 [[runners]]
   name = "${runners_name}"
   url = "${gitlab_url}"
+  clone_url = "${gitlab_clone_url}"
   token = "${runners_token}"
   executor = "${runners_executor}"
   environment = ${runners_environment_vars}

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,12 @@ variable "runners_gitlab_url" {
   type        = string
 }
 
+variable "runners_clone_url" {
+  description = "Overwrites the URL for the GitLab instance. Use only if the runner can’t connect to the GitLab URL."
+  type        = string
+  default     = ""
+}
+
 variable "runners_token" {
   description = "Token for the runner, will be used in the runner config.toml."
   type        = string


### PR DESCRIPTION
## Description

Adds the missing parameter ` clone_url` to the `config.toml` of the runner. In case the default clone URL from the GitLab project is not accessible from the runner's infrastructure (e.g. private DNS), the `clone_url` can be used to specify a different one (e.g. replace the private DNS entry by a public IP address).

Check the [configuration docs for the runner](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section).

## Migrations required

No.

## Verification

- [x] Deploy infrastructure without `clone_url`. Check that the runner can register and `config.toml` shows an empty `clone_url`. Ensure that jobs are still processed as we didn't have a `clone_url` in the config before.
- [x] Deploy infrastructure with `clone_url`. Check that the runner can register and `config.toml` shows the mentioned `clone_url`.

I check this within the Hapag-Lloyd GitLab Runner infrastructure.

