### PR TITLE
feat: do not add a the Name tag for docker+machine >= 0.16.2

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,12 +28,12 @@ locals {
   )
 
   /* determines if the docker machine executable adds the Name tag automatically (versions >= 0.16.2) */
-  docker_machine_version_used          = split(".", var.docker_machine_version)
+  # make sure to skip pre-release stuff in the semver by ignoring everything after "-"
+  docker_machine_version_used          = split(".", split("-", var.docker_machine_version)[0])
   docker_machine_version_with_name_tag = split(".", "0.16.2")
   docker_machine_version_test = [
     for i, j in reverse(range(length(local.docker_machine_version_used)))
-    # make sure to skip pre-release stuff in the semver by ignoring everything after "-"
-    : signum(split("-", local.docker_machine_version_with_name_tag[i])[0] - split("-", local.docker_machine_version_used[i])[0]) * pow(10, j)
+    : signum(local.docker_machine_version_with_name_tag[i] - local.docker_machine_version_used[i]) * pow(10, j)
   ]
 
   docker_machine_adds_name_tag = signum(sum(local.docker_machine_version_test)) <= 0

--- a/locals.tf
+++ b/locals.tf
@@ -32,6 +32,7 @@ locals {
   docker_machine_version_with_name_tag = split(".", "0.16.2")
   docker_machine_version_test = [
     for i, j in reverse(range(length(local.docker_machine_version_used)))
+    # make sure to skip pre-release stuff in the semver by ignoring everything after "-"
     : signum(split("-", local.docker_machine_version_with_name_tag[i])[0] - split("-", local.docker_machine_version_used[i])[0]) * pow(10, j)
   ]
 

--- a/locals.tf
+++ b/locals.tf
@@ -28,11 +28,11 @@ locals {
   )
 
   /* determines if the docker machine executable adds the Name tag automatically (versions >= 0.16.2) */
-  docker_machine_version_used = split(".", var.docker_machine_version)
+  docker_machine_version_used          = split(".", var.docker_machine_version)
   docker_machine_version_with_name_tag = split(".", "0.16.2")
   docker_machine_version_test = [
-  for i, j in reverse(range(length(local.docker_machine_version_used)))
-  : signum(split("-", local.docker_machine_version_with_name_tag[i])[0] - split("-", local.docker_machine_version_used[i])[0]) * pow(10, j)
+    for i, j in reverse(range(length(local.docker_machine_version_used)))
+    : signum(split("-", local.docker_machine_version_with_name_tag[i])[0] - split("-", local.docker_machine_version_used[i])[0]) * pow(10, j)
   ]
 
   docker_machine_adds_name_tag = signum(sum(local.docker_machine_version_test)) <= 0

--- a/locals.tf
+++ b/locals.tf
@@ -26,4 +26,14 @@ locals {
     runners_machine_autoscaling = var.runners_machine_autoscaling
     }
   )
+
+  /* determines if the docker machine executable adds the Name tag automatically (versions >= 0.16.2) */
+  docker_machine_version_used = split(".", var.docker_machine_version)
+  docker_machine_version_with_name_tag = split(".", "0.16.2")
+  docker_machine_version_test = [
+  for i, j in reverse(range(length(local.docker_machine_version_used)))
+  : signum(split("-", local.docker_machine_version_with_name_tag[i])[0] - split("-", local.docker_machine_version_used[i])[0]) * pow(10, j)
+  ]
+
+  docker_machine_adds_name_tag = signum(sum(local.docker_machine_version_test)) <= 0
 }

--- a/main.tf
+++ b/main.tf
@@ -89,17 +89,11 @@ locals {
       runners_additional_volumes  = local.runners_additional_volumes
       docker_machine_options      = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
       runners_name                = var.runners_name
-      runners_tags = replace(replace(var.overrides["name_docker_machine_runners"] == "" ? format(
-        "Name,%s-docker-machine,%s,%s",
-        var.environment,
+      runners_tags = replace(replace(format(
+        "%s,%s",
         local.tags_string,
         local.runner_tags_string,
-        ) : format(
-        "%s,%s,Name,%s",
-        local.tags_string,
-        local.runner_tags_string,
-        var.overrides["name_docker_machine_runners"],
-      ), ",,", ","), "/,$/", "")
+        ), ",,", ","), "/,$/", "")
       runners_token                     = var.runners_token
       runners_executor                  = var.runners_executor
       runners_limit                     = var.runners_limit

--- a/main.tf
+++ b/main.tf
@@ -73,27 +73,23 @@ locals {
 
   template_runner_config = templatefile("${path.module}/template/runner-config.tpl",
     {
-      aws_region                  = var.aws_region
-      gitlab_url                  = var.runners_gitlab_url
-      gitlab_clone_url            = var.runners_clone_url
-      runners_vpc_id              = var.vpc_id
-      runners_subnet_id           = length(var.subnet_id) > 0 ? var.subnet_id : var.subnet_id_runners
-      runners_aws_zone            = data.aws_availability_zone.runners.name_suffix
-      runners_instance_type       = var.docker_machine_instance_type
-      runners_spot_price_bid      = var.docker_machine_spot_price_bid == "on-demand-price" ? "" : var.docker_machine_spot_price_bid
-      runners_ami                 = data.aws_ami.docker_machine.id
-      runners_security_group_name = aws_security_group.docker_machine.name
-      runners_monitoring          = var.runners_monitoring
-      runners_ebs_optimized       = var.runners_ebs_optimized
-      runners_instance_profile    = aws_iam_instance_profile.docker_machine.name
-      runners_additional_volumes  = local.runners_additional_volumes
-      docker_machine_options      = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
-      runners_name                = var.runners_name
-      runners_tags = replace(replace(format(
-        "%s,%s",
-        local.tags_string,
-        local.runner_tags_string,
-      ), ",,", ","), "/,$/", "")
+      aws_region                        = var.aws_region
+      gitlab_url                        = var.runners_gitlab_url
+      gitlab_clone_url                  = var.runners_clone_url
+      runners_vpc_id                    = var.vpc_id
+      runners_subnet_id                 = length(var.subnet_id) > 0 ? var.subnet_id : var.subnet_id_runners
+      runners_aws_zone                  = data.aws_availability_zone.runners.name_suffix
+      runners_instance_type             = var.docker_machine_instance_type
+      runners_spot_price_bid            = var.docker_machine_spot_price_bid == "on-demand-price" ? "" : var.docker_machine_spot_price_bid
+      runners_ami                       = data.aws_ami.docker_machine.id
+      runners_security_group_name       = aws_security_group.docker_machine.name
+      runners_monitoring                = var.runners_monitoring
+      runners_ebs_optimized             = var.runners_ebs_optimized
+      runners_instance_profile          = aws_iam_instance_profile.docker_machine.name
+      runners_additional_volumes        = local.runners_additional_volumes
+      docker_machine_options            = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
+      runners_name                      = var.runners_name
+      runners_tags                      = replace(replace(local.runner_tags_string, ",,", ","), "/,$/", "")
       runners_token                     = var.runners_token
       runners_executor                  = var.runners_executor
       runners_limit                     = var.runners_limit

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ locals {
         "%s,%s",
         local.tags_string,
         local.runner_tags_string,
-        ), ",,", ","), "/,$/", "")
+      ), ",,", ","), "/,$/", "")
       runners_token                     = var.runners_token
       runners_executor                  = var.runners_executor
       runners_limit                     = var.runners_limit

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ locals {
       runners_instance_profile          = aws_iam_instance_profile.docker_machine.name
       runners_additional_volumes        = local.runners_additional_volumes
       docker_machine_options            = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
+      docker_machine_name               = format("%s-%s", local.runner_tags_merged["Name"], "%s") # %s is always needed
       runners_name                      = var.runners_name
       runners_tags                      = replace(replace(local.runner_tags_string, ",,", ","), "/,$/", "")
       runners_token                     = var.runners_token

--- a/tags.tf
+++ b/tags.tf
@@ -21,8 +21,8 @@ locals {
   )
 
   runner_tags = merge(
-    ! local.docker_machine_adds_name_tag ?
-      var.overrides["name_docker_machine_runners"] == "" ? { Name = format("%s-docker-machine", var.environment) } : { Name = var.overrides["name_docker_machine_runners"]}
+    !local.docker_machine_adds_name_tag ?
+    var.overrides["name_docker_machine_runners"] == "" ? { Name = format("%s-docker-machine", var.environment) } : { Name = var.overrides["name_docker_machine_runners"] }
     : {},
     var.runner_tags
   )

--- a/tags.tf
+++ b/tags.tf
@@ -20,11 +20,18 @@ locals {
     var.agent_tags
   )
 
+  runner_tags = merge(
+    ! local.docker_machine_adds_name_tag ?
+      var.overrides["name_docker_machine_runners"] == "" ? { Name = format("%s-docker-machine", var.environment) } : { Name = var.overrides["name_docker_machine_runners"]}
+    : {},
+    var.runner_tags
+  )
+
   tags_string = join(",", flatten([
     for key in keys(local.tags) : [key, lookup(local.tags, key)]
   ]))
 
   runner_tags_string = join(",", flatten([
-    for key in keys(var.runner_tags) : [key, lookup(var.runner_tags, key)]
+    for key in keys(local.runner_tags) : [key, lookup(local.runner_tags, key)]
   ]))
 }

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -45,7 +45,7 @@ listen_address = "${prometheus_listen_address}"
     IdleTime = ${runners_idle_time}
     ${runners_max_builds}
     MachineDriver = "amazonec2"
-    MachineName = "runner-%s"
+    MachineName = "${docker_machine_name}"
     MachineOptions = [
       "amazonec2-instance-type=${runners_instance_type}",
       "amazonec2-region=${aws_region}",

--- a/variables.tf
+++ b/variables.tf
@@ -573,7 +573,7 @@ variable "overrides" {
     The following attributes are supported: 
       * `name_sg` set the name prefix and overwrite the `Name` tag for all security groups created by this module. 
       * `name_runner_agent_instance` set the name prefix and override the `Name` tag for the EC2 gitlab runner instances defined in the auto launch configuration. 
-      * `name_docker_machine_runners` override the `Name` tag of EC2 instances created by the runner agent. 
+      * `name_docker_machine_runners` override the `Name` tag of EC2 instances created by the runner agent (ignored for `docker_machine_version` >= 0.16.2).
       * `name_iam_objects` set the name prefix of all AWS IAM resources created by this module.
   EOT
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -573,7 +573,7 @@ variable "overrides" {
     The following attributes are supported: 
       * `name_sg` set the name prefix and overwrite the `Name` tag for all security groups created by this module. 
       * `name_runner_agent_instance` set the name prefix and override the `Name` tag for the EC2 gitlab runner instances defined in the auto launch configuration. 
-      * `name_docker_machine_runners` override the `Name` tag of EC2 instances created by the runner agent (ignored for `docker_machine_version` >= 0.16.2).
+      * `name_docker_machine_runners` override the `Name` tag of EC2 instances created by the runner agent (used as name prefix for `docker_machine_version` >= 0.16.2).
       * `name_iam_objects` set the name prefix of all AWS IAM resources created by this module.
   EOT
   type        = map(string)


### PR DESCRIPTION
## Description

This PR checks the version of the docker machine and adds the Name tag if it is not done by the driver itself. It also removes the second `Name` tag from the `amazonec2-tags` in the `config.toml`. In consequence it is no longer possible to change the Name of the Runners as the `Name` tag is now added by the docker-machine driver (for versions >= 0.16.2).

`docker_machine_version` >= 0.16.2 automatically adds the Name tag to the EC2 instances. Adding another Name tag here causes the EC2 creation process to fail.

To be able to configure the name, `var.overrides["name_docker_machine_runners"]` is added as prefix to the name of the docker machine which is used as name for the EC2 instance by the driver.

The main logic was taken from https://github.com/hashicorp/terraform/issues/22688#issuecomment-1196805096

Closes #521 

## Migrations required

No.

## Verification

- [x] Verify the version logic manually with a `local.tf` only. Returns `true` if version >= 0.16.2
- [x] Check the `config.toml` for versions >= 0.16.2 with `overrides["name_docker_machine_runners"]`. No Name tag present.
- [x] Check the `config.toml` for versions >= 0.16.2 without `overrides["name_docker_machine_runners"]`. No Name tag present.
- [x] Check the `config.toml` for versions < 0.16.2 with `overrides["name_docker_machine_runners"]`. No Name tag equals the name set in the override.
- [x] Check the `config.toml` for versions < 0.16.2 without `overrides["name_docker_machine_runners"]`. Name tag shows `var.environment + "-docker-machine"`
- [x] Replace the current module with this version and check if tags are changed (using version < 0.16.2). There shouldn't be any change in the resource tags.

