### PR TITLE
refactor!: remove usage of `create_cache_bucket`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -307,12 +307,12 @@ locals {
 }
 
 module "cache" {
+  count  = var.cache_bucket["create"] ? 1 : 0
   source = "./modules/cache"
 
   environment = var.environment
   tags        = local.tags
 
-  create_cache_bucket                  = var.cache_bucket["create"]
   cache_bucket_prefix                  = var.cache_bucket_prefix
   cache_bucket_name_include_account_id = var.cache_bucket_name_include_account_id
   cache_bucket_set_random_suffix       = var.cache_bucket_set_random_suffix

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -26,8 +26,6 @@ resource "random_string" "s3_suffix" {
 }
 
 resource "aws_s3_bucket" "build_cache" {
-  count = var.create_cache_bucket ? 1 : 0
-
   bucket = local.cache_bucket_name
 
   tags = local.tags
@@ -36,15 +34,13 @@ resource "aws_s3_bucket" "build_cache" {
 }
 
 resource "aws_s3_bucket_acl" "build_cache_acl" {
-  count  = var.create_cache_bucket ? 1 : 0
-  bucket = aws_s3_bucket.build_cache[0].id
+  bucket = aws_s3_bucket.build_cache.id
 
   acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "build_cache_versioning" {
-  count  = var.create_cache_bucket ? 1 : 0
-  bucket = aws_s3_bucket.build_cache[0].id
+  bucket = aws_s3_bucket.build_cache.id
 
   versioning_configuration {
     status = var.cache_bucket_versioning ? "Enabled" : "Suspended"
@@ -52,8 +48,7 @@ resource "aws_s3_bucket_versioning" "build_cache_versioning" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
-  count  = var.create_cache_bucket ? 1 : 0
-  bucket = aws_s3_bucket.build_cache[0].id
+  bucket = aws_s3_bucket.build_cache.id
 
   rule {
     id     = "clear"
@@ -70,8 +65,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "build_cache_encryption" {
-  count  = var.create_cache_bucket ? 1 : 0
-  bucket = aws_s3_bucket.build_cache[0].id
+  bucket = aws_s3_bucket.build_cache.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -82,9 +76,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "build_cache_encry
 
 # block public access to S3 cache bucket
 resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
-  count = var.create_cache_bucket ? 1 : 0
-
-  bucket = aws_s3_bucket.build_cache[0].id
+  bucket = aws_s3_bucket.build_cache.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -93,8 +85,6 @@ resource "aws_s3_bucket_public_access_block" "build_cache_policy" {
 }
 
 resource "aws_iam_policy" "docker_machine_cache" {
-  count = var.create_cache_bucket ? 1 : 0
-
   name        = "${local.name_iam_objects}-docker-machine-cache"
   path        = "/"
   description = "Policy for docker machine instance to access cache"
@@ -102,7 +92,7 @@ resource "aws_iam_policy" "docker_machine_cache" {
 
   policy = templatefile("${path.module}/policies/cache.json",
     {
-      s3_cache_arn = var.create_cache_bucket == false || length(aws_s3_bucket.build_cache) == 0 ? "${var.arn_format}:s3:::fake_bucket_doesnt_exist" : aws_s3_bucket.build_cache[0].arn
+      s3_cache_arn = aws_s3_bucket.build_cache.arn
     }
   )
 }

--- a/modules/cache/outputs.tf
+++ b/modules/cache/outputs.tf
@@ -1,15 +1,15 @@
 output "policy_arn" {
   description = "Policy for users of the cache (bucket)."
-  value       = element(concat(aws_iam_policy.docker_machine_cache.*.arn, [""]), 0)
+  value       = aws_iam_policy.docker_machine_cache.arn
 }
 
 output "bucket" {
   description = "Name of the created bucket."
-  value       = element(concat(aws_s3_bucket.build_cache.*.bucket, [""]), 0)
+  value       = aws_s3_bucket.build_cache.bucket
 }
 
 output "arn" {
   description = "The ARN of the created bucket."
-  value       = element(concat(aws_s3_bucket.build_cache.*.arn, [""]), 0)
+  value       = aws_s3_bucket.build_cache.arn
 }
 

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -40,7 +40,7 @@ variable "tags" {
 }
 
 variable "create_cache_bucket" {
-  description = "This module is by default included in the runner module. To disable the creation of the bucket this parameter can be disabled."
+  description = "(deprecated) If the cache should not be craeted, remove the whole module call!"
   type        = bool
   default     = true
 }

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -42,7 +42,12 @@ variable "tags" {
 variable "create_cache_bucket" {
   description = "(deprecated) If the cache should not be craeted, remove the whole module call!"
   type        = bool
-  default     = true
+  default     = null
+
+  validation {
+    condition     = anytrue([var.create_cache_bucket == null])
+    error_message = "Deprecated, don't call the module when not creating a cache bucket."
+  }
 }
 
 variable "cache_lifecycle_clear" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,12 @@ output "runner_as_group_name" {
 
 output "runner_cache_bucket_arn" {
   description = "ARN of the S3 for the build cache."
-  value       = module.cache.arn
+  value       = element(concat(module.cache.*.arn, [""]), 0)
 }
 
 output "runner_cache_bucket_name" {
   description = "Name of the S3 for the build cache."
-  value       = module.cache.bucket
+  value       = element(concat(module.cache.*.bucket, [""]), 0)
 }
 
 output "runner_agent_role_arn" {


### PR DESCRIPTION
## Description

Marks `create_cache_bucket` deprecated to simplify the cache module. In case no cache should be created it is better to not call this module instead of setting the variable to `false`. In this case the module does nothing.

Closes #525 

## Migrations required

In case `create_cache_bucket` was set to `false`: remove the whole module call as it does nothing. Otherwise you should remove the deprecated variable.

## Verification
- [x] deploy over existing 5.1.0 deployment and check plan for changes regarding the cache
- [x] deploy cache with `create_cache_bucket = false`. Throws a validation error
- [x] deploy cache with `create_cache_bucket = true`. Throws a validation error
- [x] deploy cache. Creates the S3 bucket as usual
