### PR TITLE
fix: always add the cache policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A few option are provided to access the runner instance:
 
 ### GitLab runner cache
 
-By default the module creates a a cache for the runner in S3. Old objects are automatically removed via a configurable life cycle policy on the bucket.
+By default the module creates a cache for the runner in S3. Old objects are automatically removed via a configurable life cycle policy on the bucket.
 
 Creation of the bucket can be disabled and managed outside this module. A good use case is for sharing the cache across multiple runners. For this purpose the cache is implemented as a sub module. For more details see the [cache module](https://github.com/npalm/terraform-aws-gitlab-runner/tree/develop/cache). An example implementation of this use case can be found in the [runner-public](https://github.com/npalm/terraform-aws-gitlab-runner/tree/__GIT_REF__/examples/runner-public) example.
 

--- a/main.tf
+++ b/main.tf
@@ -399,7 +399,6 @@ resource "aws_iam_role_policy_attachment" "user_defined_policies" {
 ### Policy for the docker machine instance to access cache
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
-  count      = var.cache_bucket["create"] || lookup(var.cache_bucket, "policy", "") != "" ? 1 : 0
   role       = aws_iam_role.instance.name
   policy_arn = local.bucket_policy
 }


### PR DESCRIPTION
## Description

As described in #298 the cache module has to be applied separately before creating the Runners. Terraform complains about

```
Error: Invalid count argument

  on ..\..\..\terraform-aws-gitlab-runner\main.tf line 323, in resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance":
 323:   count      = var.cache_bucket["create"] || local.bucket_policy != "" ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

This PR always adds the policy to get rid of the error message during `apply`. As far as we know there is no use cases deploying this module without a cache. Thus we can always add the cache policy to the role.

Closes #298 

## Migrations required

No

## Verification

- [x] create a runner with a cache created separately (using the cache module). No error is shown during `apply`
- [x] create a runner and let the module create the cache. `apply` shows no error.
- [x] destroy everything without error