### PR TITLE
fix: access cache module via index

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -293,8 +293,8 @@ resource "aws_launch_template" "gitlab_runner_instance" {
 ### Create cache bucket
 ################################################################################
 locals {
-  bucket_name   = var.cache_bucket["create"] ? module.cache.bucket : lookup(var.cache_bucket, "bucket", "")
-  bucket_policy = var.cache_bucket["create"] ? module.cache.policy_arn : lookup(var.cache_bucket, "policy", "")
+  bucket_name   = var.cache_bucket["create"] ? module.cache[0].bucket : lookup(var.cache_bucket, "bucket", "")
+  bucket_policy = var.cache_bucket["create"] ? module.cache[0].policy_arn : lookup(var.cache_bucket, "policy", "")
 }
 
 module "cache" {


### PR DESCRIPTION
## Description

Fixes an error applying the cache module. As a `count` was introduced, we have to use an index to access the module's result.

## Migrations required

No

## Verification

None

