### PR TITLE
fix: ensure a maximum Runner hostname via override length of 64 characters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -584,6 +584,11 @@ variable "overrides" {
     name_runner_agent_instance  = ""
     name_docker_machine_runners = ""
   }
+
+  validation {
+    condition     = length(var.overrides["name_docker_machine_runners"]) <= 28
+    error_message = "Maximum length for name_docker_machine_runners is 28 characters!"
+  }
 }
 
 variable "cache_bucket" {


### PR DESCRIPTION
## Description

This PR makes sure that the maximum hostname length of a Runner does not exceeds the limit of 64 characters. In case the maximum length is exceeded the runners can't be created and no jobs will be processed.

- the user defined part of the hostname set by `var.overrides["name_docker_machine_runners"]` is limited to 28 characters.
- in case the `var.overrides` feature isn't used, the name is created based on `var.environment` plus a `-docker-machine` suffix. If the name of the environment is too long we simply substring everything to 28 characters.

Closes #536 

## Migrations required

No

## Verification

- [x] Deploy this version over 5.2.1, check the plan and execute a job on the new runner. The runner starts and processes the job. The plan does not show any change.
- [x] Deploy this version from scratch, check the plan and execute a job on the new runner. The runner starts and processes the job.
- [x] Make sure that a long `var.environment` (at least 29 characters) creates a runner hostname of 64 characters.
- [x] Use a `var.overrides["name_docker_machine_runners"]` of at least 29 characters. The plan fails with an error message.