### PR TITLE
fix: do not add the cache access policy if there is none

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -390,7 +390,7 @@ resource "aws_iam_role_policy_attachment" "user_defined_policies" {
 ### Policy for the docker machine instance to access cache
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
-  count = var.cache_bucket["create"] ? 1 : 0
+  count = var.cache_bucket["create"] || length(lookup(var.cache_bucket, "policy", "")) > 0 ? 1 : 0
 
   role       = aws_iam_role.instance.name
   policy_arn = local.bucket_policy

--- a/main.tf
+++ b/main.tf
@@ -390,6 +390,8 @@ resource "aws_iam_role_policy_attachment" "user_defined_policies" {
 ### Policy for the docker machine instance to access cache
 ################################################################################
 resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
+  count = var.cache_bucket["create"] ? 1 : 0
+
   role       = aws_iam_role.instance.name
   policy_arn = local.bucket_policy
 }


### PR DESCRIPTION
## Description

In case the module does not create the cache and `var.cache_bucket["policy"]` is empty, the module can't be deployed as explained in  https://github.com/npalm/terraform-aws-gitlab-runner/pull/528#issuecomment-1234004003.

This PR makes sure to add the policy only if it exists.

## Migrations required

No.

## Verification

- [x] Deploy the module without creating a cache and setting the `policy`. Module is created without any error.

