### PR TITLE
chore: use latest Gitlab runner version by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -389,7 +389,7 @@ variable "cache_shared" {
 variable "gitlab_runner_version" {
   description = "Version of the [GitLab runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases)."
   type        = string
-  default     = "14.8.3"
+  default     = "15.3.0"
 }
 
 variable "enable_ping" {


### PR DESCRIPTION
## Description
use latest Gitlab runner version by default

## Migrations required

NO


