### PR TITLE
feat: add runners_pull_policies

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -27,6 +27,8 @@ locals {
     }
   )
 
+  runners_pull_policies = var.runners_pull_policy != "" ? "[${var.runners_pull_policy}]" : "[\"${join(var.runners_pull_policies, "\",\"")}\"]"
+
   /* determines if the docker machine executable adds the Name tag automatically (versions >= 0.16.2) */
   # make sure to skip pre-release stuff in the semver by ignoring everything after "-"
   docker_machine_version_used          = split(".", split("-", var.docker_machine_version)[0])

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ locals {
       runners_docker_runtime            = var.runners_docker_runtime
       runners_helper_image              = var.runners_helper_image
       runners_shm_size                  = var.runners_shm_size
-      runners_pull_policy               = var.runners_pull_policy
+      runners_pull_policies             = local.runners_pull_policies
       runners_idle_count                = var.runners_idle_count
       runners_idle_time                 = var.runners_idle_time
       runners_max_builds                = local.runners_max_builds_string

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -24,7 +24,7 @@ listen_address = "${prometheus_listen_address}"
     disable_cache = ${runners_disable_cache}
     volumes = ["/cache"${runners_additional_volumes}]
     shm_size = ${runners_shm_size}
-    pull_policy = "${runners_pull_policy}"
+    pull_policy = ${runners_pull_policy}
     runtime = "${runners_docker_runtime}"
     helper_image = "${runners_helper_image}"
   [runners.docker.tmpfs]

--- a/variables.tf
+++ b/variables.tf
@@ -232,9 +232,15 @@ variable "runners_helper_image" {
 }
 
 variable "runners_pull_policy" {
-  description = "pull_policy for the runners, will be used in the runner config.toml"
+  description = "Deprecated! Use runners_pull_policies instead. pull_policy for the runners, will be used in the runner config.toml"
   type        = string
   default     = "always"
+}
+
+variable "runners_pull_policies" {
+  description = "pull policies for the runners, will be used in the runner config.toml, for Gitlab Runner >= 13.8, see https://docs.gitlab.com/runner/executors/docker.html#using-multiple-pull-policies "
+  type        = list(string)
+  default     = ["always"]
 }
 
 variable "runners_monitoring" {


### PR DESCRIPTION
## Description

Support multiple Docker pull policies. The pull_policy parameter allows to specify a list of pull policies. The policies in the list will be attempted in order from left to right until a pull attempt is successful, or the list is exhausted.

https://docs.gitlab.com/runner/executors/docker.html#how-pull-policies-work

## Migrations required

YES - Deprecate runners_pull_policy in favor of runners_pull_policies

## Verification

Please mention the examples you have verified.

