### PR TITLE
feat: Skip yum update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ locals {
       logging             = var.enable_cloudwatch_logging ? local.logging_user_data : ""
       gitlab_runner       = local.template_gitlab_runner
       user_data_trace_log = var.enable_runner_user_data_trace_log
-      runner_yum_update   = var.runner_yum_update
+      ryu                 = var.runner_yum_update
   })
 
   template_eip = templatefile("${path.module}/template/eip.tpl", {

--- a/main.tf
+++ b/main.tf
@@ -40,10 +40,10 @@ locals {
       logging             = var.enable_cloudwatch_logging ? local.logging_user_data : ""
       gitlab_runner       = local.template_gitlab_runner
       user_data_trace_log = var.enable_runner_user_data_trace_log
-      yum_update          = var.runner_yum_update ? local.template_yum_update : ""
+      yum_update          = var.runner_yum_update ? local.file_yum_update : ""
   })
 
-  template_yum_update = templatefile("${path.module}/template/yum_update.tpl")
+  file_yum_update = file("${path.module}/template/yum_update.tpl")
 
   template_eip = templatefile("${path.module}/template/eip.tpl", {
     eip = join(",", aws_eip.gitlab_runner.*.public_ip)

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ locals {
       logging             = var.enable_cloudwatch_logging ? local.logging_user_data : ""
       gitlab_runner       = local.template_gitlab_runner
       user_data_trace_log = var.enable_runner_user_data_trace_log
-      do_yum_update       = var.do_yum_update
+      runner_yum_update   = var.runner_yum_update
   })
 
   template_eip = templatefile("${path.module}/template/eip.tpl", {

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,10 @@ locals {
       logging             = var.enable_cloudwatch_logging ? local.logging_user_data : ""
       gitlab_runner       = local.template_gitlab_runner
       user_data_trace_log = var.enable_runner_user_data_trace_log
-      ryu                 = var.runner_yum_update
+      yum_update          = var.runner_yum_update ? local.template_yum_update : ""
   })
+
+  template_yum_update = templatefile("${path.module}/template/yum_update.tpl")
 
   template_eip = templatefile("${path.module}/template/eip.tpl", {
     eip = join(",", aws_eip.gitlab_runner.*.public_ip)

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ locals {
       logging             = var.enable_cloudwatch_logging ? local.logging_user_data : ""
       gitlab_runner       = local.template_gitlab_runner
       user_data_trace_log = var.enable_runner_user_data_trace_log
+      do_yum_update       = var.do_yum_update
   })
 
   template_eip = templatefile("${path.module}/template/eip.tpl", {

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -14,7 +14,7 @@ token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-m
 
 ${eip}
 
-if [[ `echo ${do_yum_update}` == "true" ]]
+if [[ `echo ${runner_yum_update}` == "true" ]]
 then
   for i in {1..7}; do
     echo "Attempt: ---- " $i

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -14,14 +14,7 @@ token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-m
 
 ${eip}
 
-# Checking terraform boolean (1 is true)
-if [[ "$ryu -eq "1" || "$ryu == "true" || "$ryu == "t" || "$ryu == "enable" ]]
-then
-  for i in {1..7}; do
-    echo "Attempt: ---- " $i
-    yum -y update && break || sleep 60
-  done
-fi
+${yum_update}
 
 ${logging}
 

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -14,7 +14,8 @@ token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-m
 
 ${eip}
 
-if [[ `echo ${runner_yum_update}` == "true" ]]
+# Checking terraform boolean (1 is true)
+if [[ "$ryu -eq "1" || "$ryu == "true" || "$ryu == "t" || "$ryu == "enable" ]]
 then
   for i in {1..7}; do
     echo "Attempt: ---- " $i

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -14,10 +14,13 @@ token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-m
 
 ${eip}
 
-for i in {1..7}; do
-  echo "Attempt: ---- " $i
-  yum -y update && break || sleep 60
-done
+if [[ `echo ${do_yum_update}` == "true" ]]
+then
+  for i in {1..7}; do
+    echo "Attempt: ---- " $i
+    yum -y update && break || sleep 60
+  done
+fi
 
 ${logging}
 

--- a/template/yum_update.tpl
+++ b/template/yum_update.tpl
@@ -1,0 +1,4 @@
+for i in {1..7}; do
+  echo "Attempt: ---- " $i
+  yum -y update && break || sleep 60
+done

--- a/variables.tf
+++ b/variables.tf
@@ -814,8 +814,8 @@ variable "asg_terminate_lifecycle_lambda_timeout" {
   type        = number
 }
 
-variable "do_yum_update" {
-  description = "Run a yum update as part of starting the instance"
+variable "runner_yum_update" {
+  description = "Run a yum update as part of starting the runner"
   default     = "true"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -813,3 +813,9 @@ variable "asg_terminate_lifecycle_lambda_timeout" {
   default     = 30
   type        = number
 }
+
+variable "do_yum_update" {
+  description = "Run a yum update as part of starting the instance"
+  default     = "true"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -816,6 +816,6 @@ variable "asg_terminate_lifecycle_lambda_timeout" {
 
 variable "runner_yum_update" {
   description = "Run a yum update as part of starting the runner"
-  default     = "true"
-  type        = string
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
## Description

This will allow for runners to be launched from a known working AMI and not have yum update introduce unexpected issues.
The default is to run the yum update as is current but allows for disabling.

## Migrations required

NO - Existing behaviour not changed

## Verification

Please mention the examples you have verified.
Tests based on Example - Spot Runner - Default without issue.

