### PR TITLE
fix: Too long host names for docker machines

### DIFF
--- a/tags.tf
+++ b/tags.tf
@@ -24,7 +24,7 @@ locals {
     local.tags,
     var.runner_tags,
     # overwrites the `Name` key from `local.tags`
-    var.overrides["name_docker_machine_runners"] == "" ? { Name = format("%s-docker-machine", var.environment) } : { Name = var.overrides["name_docker_machine_runners"] },
+    var.overrides["name_docker_machine_runners"] == "" ? { Name = substr(format("%s", var.environment), 0, 16) } : { Name = var.overrides["name_docker_machine_runners"] },
   )
 
   # remove the `Name` tag if docker+machine adds one to avoid a failure due to a duplicate `Name` tag


### PR DESCRIPTION
## Description

Docker machine instance not starting caused by to long names. Enforced the max length.

fix: #536 

## Migrations required

NO

## Verification

default example
