### PR TITLE
refactor: remove `arn_format`

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -7,7 +7,7 @@ resource "aws_kms_key" "default" {
   tags                    = local.tags
   policy = templatefile("${path.module}/policies/kms-policy.json",
     {
-      arn_format = var.arn_format
+      partition = data.aws_partition.current.partition
       aws_region = var.aws_region
       account_id = data.aws_caller_identity.current.account_id
     }

--- a/kms.tf
+++ b/kms.tf
@@ -7,7 +7,7 @@ resource "aws_kms_key" "default" {
   tags                    = local.tags
   policy = templatefile("${path.module}/policies/kms-policy.json",
     {
-      partition = data.aws_partition.current.partition
+      partition  = data.aws_partition.current.partition
       aws_region = var.aws_region
       account_id = data.aws_caller_identity.current.account_id
     }

--- a/logging.tf
+++ b/logging.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role_policy" "instance" {
   count  = var.enable_cloudwatch_logging ? 1 : 0
   name   = "${local.name_iam_objects}-instance-role"
   role   = aws_iam_role.instance.name
-  policy = templatefile("${path.module}/policies/instance-logging-policy.json", { arn_format = var.arn_format })
+  policy = templatefile("${path.module}/policies/instance-logging-policy.json", { partition = data.aws_partition.current.partition })
 }
 
 locals {

--- a/policies/instance-logging-policy.json
+++ b/policies/instance-logging-policy.json
@@ -11,7 +11,7 @@
         "logs:DescribeLogStreams"
       ],
       "Resource": [
-        "${arn_format}:logs:*:*:*"
+        "arn:${partition}:logs:*:*:*"
       ]
     }
   ]

--- a/policies/instance-secure-parameter-role-policy.json
+++ b/policies/instance-secure-parameter-role-policy.json
@@ -13,7 +13,7 @@
             "Action": [
                 "ssm:GetParameters"
             ],
-            "Resource": "${arn_format}:ssm:*"
+            "Resource": "arn:${partition}:ssm:*"
         }
     ]
 }

--- a/policies/kms-policy.json
+++ b/policies/kms-policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "${arn_format}:iam::${account_id}:root"
+          "arn:${partition}:iam::${account_id}:root"
         ]
       },
       "Action": "kms:*",

--- a/policies/service-linked-role-create-policy.json
+++ b/policies/service-linked-role-create-policy.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": "iam:CreateServiceLinkedRole",
-      "Resource": "${arn_format}:iam::*:role/aws-service-role/*"
+      "Resource": "arn:${partition}:iam::*:role/aws-service-role/*"
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "aws_region" {
 variable "arn_format" {
   type        = string
   default     = "arn:aws"
-  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions."
+  description = "Deprecated! Calculated automatically by the module. ARN format to be used. May be changed to support deployment in GovCloud/China regions."
 }
 
 variable "auth_type_cache_sr" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "aws_region" {
 
 variable "arn_format" {
   type        = string
-  default     = "arn:aws"
+  default     = null
   description = "Deprecated! Calculated automatically by the module. ARN format to be used. May be changed to support deployment in GovCloud/China regions."
 }
 


### PR DESCRIPTION
## Description

The `arn_format` used for US Gov and China can be calculated with `aws_partition`. Thus the parameter in the module is obsolete, marked as deprecated and should by removed with the next major release.

## Migrations required

No, but you should remove the `arn_format` parameter from the module call as it is no longer in use.

## Verification

- [x] create a plan for the runner-default example and check that the ARNs in the policies still read `arn:aws`

