### PR TITLE
fix: Set pull_policy instead of allowed_pull_policies

### DIFF
--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -25,7 +25,7 @@ listen_address = "${prometheus_listen_address}"
     volumes = ["/cache"${runners_additional_volumes}]
     extra_hosts = ${jsonencode(runners_extra_hosts)}
     shm_size = ${runners_shm_size}
-    allowed_pull_policies = ${runners_pull_policies}
+    pull_policy = ${runners_pull_policies}
     runtime = "${runners_docker_runtime}"
     helper_image = "${runners_helper_image}"
   [runners.docker.tmpfs]


### PR DESCRIPTION
## Description

Since #544 was merged in, `runners_pull_policies` is used to set the runner's `allowed_pull_policies` instead of `pull_policy`. That is confusing, and it changes the behaviour of the directive and prevents setting the default pull policy for the runner.

This change switches back to using `runners_pull_policies` to set the runner's `pull_policy`, while still allowing for multiple policies to be defined.

## Migrations required

NO

## Verification

I have verified that the correct `pull_policy` directive is now set on the runners.

