### PR TITLE
Zip user_data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,7 @@ data "aws_ami" "runner" {
 resource "aws_launch_template" "gitlab_runner_instance" {
   name_prefix            = local.name_runner_agent_instance
   image_id               = data.aws_ami.runner.id
-  user_data              = base64encode(local.template_user_data)
+  user_data              = base64gzip(local.template_user_data)
   instance_type          = var.instance_type
   update_default_version = true
   ebs_optimized          = var.runner_instance_ebs_optimized


### PR DESCRIPTION
## Description

Closes #561 

## Migrations required

NO

## Verification

Done:
EC2 runner working correctly in my environment for several days now.
On the EC2 Launch Template, User data is visible as b64 + gzip encoded.
On the EC2 instance panel, User data displays as "No user data" for some reason.