### PR TITLE
Allow custom runner agent IAM role fixups (#572)

### DIFF
--- a/logging.tf
+++ b/logging.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role_policy" "instance" {
-  count  = var.enable_cloudwatch_logging ? 1 : 0
-  name   = "${local.name_iam_objects}-instance-role"
+  count  = var.enable_cloudwatch_logging && var.create_runner_iam_role ? 1 : 0
+  name   = "${local.name_iam_objects}-logging"
   role   = local.aws_iam_role_instance_name
   policy = templatefile("${path.module}/policies/instance-logging-policy.json", { partition = data.aws_partition.current.partition })
 }

--- a/main.tf
+++ b/main.tf
@@ -243,7 +243,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     }
   }
   iam_instance_profile {
-    name = aws_iam_instance_profile.instance.name
+    name = local.aws_iam_role_instance_name
   }
   dynamic "block_device_mappings" {
     for_each = [var.runner_root_block_device]
@@ -322,14 +322,16 @@ module "cache" {
 ### Trust policy
 ################################################################################
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.name_iam_objects}-instance"
+  count = var.create_runner_iam_role ? 1 : 0
+
+  name = local.aws_iam_role_instance_name
   role = local.aws_iam_role_instance_name
   tags = local.tags
 }
 
 resource "aws_iam_role" "instance" {
   count                = var.create_runner_iam_role ? 1 : 0
-  name                 = "${local.name_iam_objects}-instance"
+  name                 = local.aws_iam_role_instance_name
   assume_role_policy   = length(var.instance_role_json) > 0 ? var.instance_role_json : templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   permissions_boundary = var.permissions_boundary == "" ? null : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}"
   tags                 = merge(local.tags, var.role_tags)
@@ -341,6 +343,7 @@ resource "aws_iam_role" "instance" {
 ### iam:PassRole To pass the role from the agent to the docker machine runners
 ################################################################################
 resource "aws_iam_policy" "instance_docker_machine_policy" {
+  count       = var.create_runner_iam_role ? 1 : 0
   name        = "${local.name_iam_objects}-docker-machine"
   path        = "/"
   description = "Policy for docker machine."
@@ -352,8 +355,10 @@ resource "aws_iam_policy" "instance_docker_machine_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "instance_docker_machine_policy" {
+  count = var.create_runner_iam_role ? 1 : 0
+
   role       = local.aws_iam_role_instance_name
-  policy_arn = aws_iam_policy.instance_docker_machine_policy.arn
+  policy_arn = aws_iam_policy.instance_docker_machine_policy[count.index].arn
 }
 
 ################################################################################
@@ -387,7 +392,8 @@ resource "aws_iam_role_policy_attachment" "instance_session_manager_aws_managed"
 ### Add user defined policies
 ################################################################################
 resource "aws_iam_role_policy_attachment" "user_defined_policies" {
-  count      = length(var.runner_iam_policy_arns)
+  count = length(var.runner_iam_policy_arns)
+
   role       = local.aws_iam_role_instance_name
   policy_arn = var.runner_iam_policy_arns[count.index]
 }


### PR DESCRIPTION
## Description

Fixups relating to #572 

When a custom role is specified we should also have ability to avoid attaching any additional policies to the role, in the case when the custom role already has enough permissions (and may be at/near the 20 attached policies limit).

Also disable creating the instance profile when we aren't also creating the role.
This means multiple copies of the runner module can be made safely with the same custom role and without duplicating the instance profile. Though duplicating the instance profile doesn't cause any errors it is unexpected, in the AWS IAM console you can only see a single instance profile for a role. Allocating 2 or more seems to have no effect and Terraform doesn't seem to pick this up as an error condition either.

## Migrations required

NO

## Verification

I've manually tested the changes in my own environment. 