### PR TITLE
feat: Support volume type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_runners_request_concurrency"></a> [runners\_request\_concurrency](#input\_runners\_request\_concurrency) | Limit number of concurrent requests for new jobs from GitLab (default 1). | `number` | `1` | no |
 | <a name="input_runners_request_spot_instance"></a> [runners\_request\_spot\_instance](#input\_runners\_request\_spot\_instance) | Whether or not to request spot instances via docker-machine | `bool` | `true` | no |
 | <a name="input_runners_root_size"></a> [runners\_root\_size](#input\_runners\_root\_size) | Runner instance root size in GB. | `number` | `16` | no |
+| <a name="input_runners_volume_type"></a> [runners\_volume\_type](#input\_runners\_volume\_type_) | Runner instance volume type. | `string` | `gp2` | no |
 | <a name="input_runners_services_volumes_tmpfs"></a> [runners\_services\_volumes\_tmpfs](#input\_runners\_services\_volumes\_tmpfs) | Mount a tmpfs in gitlab service container. https://docs.gitlab.com/runner/executors/docker.html#mounting-a-directory-in-ram | <pre>list(object({<br>    volume  = string<br>    options = string<br>  }))</pre> | `[]` | no |
 | <a name="input_runners_shm_size"></a> [runners\_shm\_size](#input\_runners\_shm\_size) | shm\_size for the runners, will be used in the runner config.toml | `number` | `0` | no |
 | <a name="input_runners_token"></a> [runners\_token](#input\_runners\_token) | Token for the runner, will be used in the runner config.toml. | `string` | `"__REPLACED_BY_USER_DATA__"` | no |

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ locals {
       runners_max_builds                = local.runners_max_builds_string
       runners_machine_autoscaling       = local.runners_machine_autoscaling
       runners_root_size                 = var.runners_root_size
+      runners_volume_type               = var.runners_volume_type
       runners_iam_instance_profile_name = var.runners_iam_instance_profile_name
       runners_use_private_address_only  = var.runners_use_private_address
       runners_use_private_address       = !var.runners_use_private_address

--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -63,6 +63,7 @@ listen_address = "${prometheus_listen_address}"
       "amazonec2-monitoring=${runners_monitoring}",
       "amazonec2-iam-instance-profile=%{ if runners_iam_instance_profile_name != "" }${runners_iam_instance_profile_name}%{ else }${runners_instance_profile}%{ endif ~}",
       "amazonec2-root-size=${runners_root_size}",
+      "amazonec2-volume-type=${runners_volume_type}",
       "amazonec2-ami=${runners_ami}"
       ${docker_machine_options}
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -278,6 +278,12 @@ variable "runners_root_size" {
   default     = 16
 }
 
+variable "runners_volume_type" {
+  description = "Runner instance volume type"
+  type        = string
+  default     = "gp2"
+}
+
 variable "runners_iam_instance_profile_name" {
   description = "IAM instance profile name of the runners, will be used in the runner config.toml"
   type        = string


### PR DESCRIPTION
## Description

Allow setting a configurable parameter to set the EBS volume type on the instances spawned to run jobs. This defaults to gp2, and is not required

Fixes https://github.com/npalm/terraform-aws-gitlab-runner/issues/578

A few sentences describing the overall goals of the pull request's commits.

## Migrations required

NO

## Verification

Please mention the examples you have verified.

