### PR TITLE
ci: fix the TfDocs creation in feature branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
     - name: CHeckout branch
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
     - name: CHeckout branch
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.ref }}
 
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
     steps:
     - name: CHeckout branch
       uses: actions/checkout@v3
-
+      with:
+        ref: ${{ github.head_ref }}
+        
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,27 +46,6 @@ jobs:
         run: terraform fmt -recursive -check=true -write=false
       - run: terraform validate
 
-  docs:
-    # update docs after merge back to main
-    if: github.event_name == 'pull_request'
-    name: Auto update terraform docs
-    needs: [verify_module, verify_examples]
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: CHeckout branch
-      uses: actions/checkout@v3
-        
-    - name: Generate TF docs
-      uses: terraform-docs/gh-actions@v1.0.0
-      with:
-        find-dir: .
-        git-commit-message: "docs: auto update terraform docs"
-        git-push: false
-
-    - uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: "docs: auto update terraform docs"
   tfsec:
     name: tfsec PR commenter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: CHeckout branch
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.ref }}
 
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,17 @@ jobs:
     steps:
     - name: CHeckout branch
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
         
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         find-dir: .
         git-commit-message: "docs: auto update terraform docs"
-        git-push: true
+        git-push: false
 
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "docs: auto update terraform docs"
   tfsec:
     name: tfsec PR commenter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
     - name: CHeckout branch
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Generate TF docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,0 +1,23 @@
+name: Update docs
+
+on:
+  push:
+    branches:
+      - release-please--branches--main
+
+jobs:
+  docs:
+    # update docs after merge back to develop
+    name: Auto update terraform docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Generate TF docs
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          find-dir: .
+          git-commit-message: "docs: auto update terraform docs"
+          git-push: true

--- a/README.md
+++ b/README.md
@@ -359,8 +359,6 @@ Made with [contributors-img](https://contrib.rocks).
 
 ## Modules
 
-test
-
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cache"></a> [cache](#module\_cache) | ./modules/cache | n/a |

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Made with [contributors-img](https://contrib.rocks).
 
 ## Modules
 
+test
+
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cache"></a> [cache](#module\_cache) | ./modules/cache | n/a |


### PR DESCRIPTION
The workflow was not running in case the PR was created from a foreign repository. The checkout of the branch didn't succeed.

The TF docs are now generated in the release branch if a commit is pushed.