### PR TITLE
Fix "No roles attached to instance profile"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -248,7 +248,8 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     }
   }
   iam_instance_profile {
-    name = local.aws_iam_role_instance_name
+    arn  = var.create_runner_iam_role ? aws_iam_instance_profile.instance[0].arn : null
+    name = var.create_runner_iam_role ? null : local.aws_iam_role_instance_name
   }
   dynamic "block_device_mappings" {
     for_each = [var.runner_root_block_device]


### PR DESCRIPTION
## Description

For some reason, the EC2 instances created by the launch template do not automatically associate with the appropriate IAM Role, even though the name matches correctly. This change fixes this by using the ARN of the created role directly.

## Migrations required

NO

## Verification

Changing this line and re-applying on Terraform allowed the EC2 instance to associate with the correct IAM Role as expected.
