### PR TITLE
chore: mark PRs and issues as stale and auto-close them

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '25 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
+          days-before-stale: 60
+          days-before-close: 15


### PR DESCRIPTION
Adds a workflow to mark issues and PRs after 60 days as stale and auto-close them after another 15 days. This helps to remove everything we are not actively working on.