### PR TITLE
chore: fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,7 @@ updates:
     commit_message:
       prefix: "chore"
 
-
-  - package-ecosystem: "actions"
+  - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,39 @@
+---
 version: 2
+
 updates:
   - package-ecosystem: "terraform"
     directory: "/examples/runner-default"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit_message:
       prefix: "chore"
   - package-ecosystem: "terraform"
     directory: "/examples/runner-docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit_message:
       prefix: "chore"
   - package-ecosystem: "terraform"
     directory: "/examples/runner-public"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit_message:
       prefix: "chore"
   - package-ecosystem: "terraform"
     directory: "/examples/pre-registered"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit_message:
+      prefix: "chore"
+  - package-ecosystem: "terraform"
+    directory: "/examples/multi-region"
+    schedule:
+      interval: "weekly"
     commit_message:
       prefix: "chore"
 
-  # Enable version updates for Docker
+
   - package-ecosystem: "actions"
     directory: "/.github/workflows"
     schedule:


### PR DESCRIPTION
This PR fixes the Dependabot setup:

* add missing example directory `/examples/multi-region` to Dependabot
* use weekly updates instead of daily updates for examples
* use correct `package-ecosystem` to allow Dependabot to update the workflows