### PR TITLE
docs: detail the policies for KMS keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 }
 ```
 
+### KMS keys
+
+If a KMS key is set via `kms_key_id`, make sure that you also give proper access to the key. Otherwise, you might
+get errors, e.g. the build cache can't be decrypted or logging via CloudWatch is not possible. For a CloudWatch
+example checkout [kms-policy.json](https://github.com/npalm/terraform-aws-gitlab-runner/blob/main/policies/kms-policy.json)
+
 ### GitLab runner token configuration
 
 By default the runner is registered on initial deployment. In previous versions of this module this was a manual process. The manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS SSM parameter store. See [example](examples/runner-pre-registered/) for more details.

--- a/modules/cache/variables.tf
+++ b/modules/cache/variables.tf
@@ -87,7 +87,7 @@ variable "name_iam_objects" {
 }
 
 variable "kms_key_id" {
-  description = "KMS key id to encrypted the resources."
+  description = "KMS key id to encrypted the resources. Ensure that your Runner/Executor has access to the KMS key."
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -708,7 +708,7 @@ variable "runners_docker_services" {
 }
 
 variable "kms_key_id" {
-  description = "KMS key id to encrypted the CloudWatch logs. Ensure CloudWatch has access to the provided KMS key."
+  description = "KMS key id to encrypted the resources. Ensure CloudWatch and Runner/Executor have access to the provided KMS key."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description

Adds a few sentences and examples to make clear what policies are needed for a customer defined KMS key.

Closes #610 

## Migrations required

No.

## Verification

No verification. Documentation only.
