### PR TITLE
feat: add user data of agent to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -52,3 +52,8 @@ output "runner_launch_template_name" {
   description = "The name of the runner's launch template."
   value       = aws_launch_template.gitlab_runner_instance.name
 }
+
+output "runner_user_data" {
+  description = "The user data of the Gitlab Runner Agent's launch template."
+  value       = local.template_user_data
+}


### PR DESCRIPTION
## Description

Adds a new output `runner_user_data` to the module to show the value of the `user_data` script. Especially useful as the the script is now gzipped.

Closes #321 

## Migrations required

No

## Verification

No verification done. One output added only.
