### PR TITLE
chore: fix syntax error in `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-npalm:
+github: npalm


### PR DESCRIPTION
Correct syntax for `FUNDING.yml` is: `github: userid`. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
