### PR TITLE
ci(deps): bump TfSec commenter to 1.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,6 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@master
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
Workflows are failing at the moment with "403 Rate Limit" error when running TfSec. Instead of waiting for Dependabot, I bump the version manually.

[Version 1.3.0](https://github.com/aquasecurity/tfsec-pr-commenter-action/releases/tag/v1.3.0) fixes the problem with the rate limiting.