### PR TITLE
docs: add handling instructions for self managed cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ on .terraform/modules/gitlab_runner/main.tf line 400, in resource "aws_iam_role_
 The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.
 ```
 
-The workaround is to use a `terraform apply -target module.cache` followed by a `terraform apply` to apply everything else. This is a one time effort needed at the very beginning.
+The workaround is to use a `terraform apply -target=module.cache` followed by a `terraform apply` to apply everything else. This is a one time effort needed at the very beginning.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ In case you enable the access logging for the S3 cache bucket, you have to add t
 }
 ```
 
+In case you manage the S3 cache bucket yourself it might be necessary to apply the cache before applying the runner module. A typical error message looks like:
+
+```text
+Error: Invalid count argument
+on .terraform/modules/gitlab_runner/main.tf line 400, in resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance":
+  count = var.cache_bucket["create"] || length(lookup(var.cache_bucket, "policy", "")) > 0 ? 1 : 0
+The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.
+```
+
+The workaround is to use a `terraform apply -target module.cache` followed by a `terraform apply` to apply everything else. This is a one time effort needed at the very beginning.
+
 ## Usage
 
 ### Configuration


### PR DESCRIPTION
## Description

Amends the documentation and describes what to do in case of a Terraform error if the cache S3 bucket is self managed. It needs a separate Terraform run to apply the changes of the cache module first.

Closes #590 

