### PR TITLE
feat: add validation rule for docker machine name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -619,6 +619,11 @@ variable "overrides" {
     condition     = length(var.overrides["name_docker_machine_runners"]) <= 28
     error_message = "Maximum length for name_docker_machine_runners is 28 characters!"
   }
+  
+  validation {
+    condition = var.overrides["name_docker_machine_runners"] != "" && can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
+    error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]"
+  }
 }
 
 variable "cache_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -621,7 +621,7 @@ variable "overrides" {
   }
   
   validation {
-    condition = var.overrides["name_docker_machine_runners"] != "" && can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
+    condition = var.overrides["name_docker_machine_runners"] == "" || can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
     error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -622,7 +622,7 @@ variable "overrides" {
   
   validation {
     condition = var.overrides["name_docker_machine_runners"] != "" && can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
-    error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]"
+    error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -619,7 +619,7 @@ variable "overrides" {
     condition     = length(var.overrides["name_docker_machine_runners"]) <= 28
     error_message = "Maximum length for name_docker_machine_runners is 28 characters!"
   }
-  
+
   validation {
     condition     = var.overrides["name_docker_machine_runners"] == "" || can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
     error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]."

--- a/variables.tf
+++ b/variables.tf
@@ -621,7 +621,7 @@ variable "overrides" {
   }
   
   validation {
-    condition = var.overrides["name_docker_machine_runners"] == "" || can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
+    condition     = var.overrides["name_docker_machine_runners"] == "" || can(regex("^[a-zA-Z0-9\\.-]+$", var.overrides["name_docker_machine_runners"]))
     error_message = "Valid characters for the docker machine name are: [a-zA-Z0-9\\.-]."
   }
 }


### PR DESCRIPTION
## Description

Adds a custom validation to the `var.overrides["name_docker_machine_runners"]` variable and makes sure that valid characters are used only. Otherwise the executor (docker+machine) instances can't be created and no jobs from Gitlab are processed.

Related to #447 

## Migrations required

No.

## Verification

Still pending

- [x] Use invalid characters for the name. Terraform reports an error message.
- [x] Use all valid characters. Terraform creates the plan.
- [x] Do not use the override. Terraform creates the plan.
