### PR TITLE
fix: create the log group before creating the runner agent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -297,6 +297,9 @@ resource "aws_launch_template" "gitlab_runner_instance" {
   lifecycle {
     create_before_destroy = true
   }
+
+  # otherwise the agent running on the EC2 instance tries to create the log group
+  depends_on = [aws_cloudwatch_log_group.environment]
 }
 
 ################################################################################

--- a/policies/instance-logging-policy.json
+++ b/policies/instance-logging-policy.json
@@ -5,7 +5,6 @@
       "Sid": "allowLoggingToCloudWatch",
       "Effect": "Allow",
       "Action": [
-        "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",
         "logs:DescribeLogStreams"

--- a/policies/instance-logging-policy.json
+++ b/policies/instance-logging-policy.json
@@ -5,6 +5,7 @@
       "Sid": "allowLoggingToCloudWatch",
       "Effect": "Allow",
       "Action": [
+        "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",
         "logs:DescribeLogStreams"


### PR DESCRIPTION
## Description

In some cases Terraform reports an error message and can't create the log group for the runner agent. The reason is, that the Cloudwatch agent running on the EC2 instance is already up and creates the log group before Terraform does it. This should never happen.

Attention: The policy `logs:CreateLogGroup` can't be removed. It shouldn't be needed by the Cloudwatch agent, but if it is not attached, no log streams are created within the log group and thus no logs are visible.

## Migrations required

No

## Verification

Module deployed and verified that the log group/stream is populated with logging data.
