### PR TITLE
ci: enable Dependabot updates for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,24 +8,28 @@ updates:
       interval: "weekly"
     commit_message:
       prefix: "chore"
+
   - package-ecosystem: "terraform"
     directory: "/examples/runner-docker"
     schedule:
       interval: "weekly"
     commit_message:
       prefix: "chore"
+
   - package-ecosystem: "terraform"
     directory: "/examples/runner-public"
     schedule:
       interval: "weekly"
     commit_message:
       prefix: "chore"
+
   - package-ecosystem: "terraform"
     directory: "/examples/pre-registered"
     schedule:
       interval: "weekly"
     commit_message:
       prefix: "chore"
+
   - package-ecosystem: "terraform"
     directory: "/examples/multi-region"
     schedule:
@@ -37,5 +41,12 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    commit_message:
+      prefix: "chore"
+
+  - package-ecosystem: gomod
+    directory: /test
+    schedule:
+      interval: weekly
     commit_message:
       prefix: "chore"


### PR DESCRIPTION
## Description

Tests are written in Go and thus the Go dependencies should be updated automatically to the newest version. This PR changes the Dependabot configuration to allow automatic updates.
