### PR TITLE
ci: use lowercase `stale` label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,5 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
           days-before-stale: 60
           days-before-close: 15
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'


### PR DESCRIPTION
## Description

All labels in this project starts with a lowercase letter, except the one for `Stale` issues. This PR streamlines the label used to mark stale issues and PRs. The label used is `stale`
