### PR TITLE
ci: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,47 +6,47 @@ updates:
     directory: "/examples/runner-default"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "terraform"
     directory: "/examples/runner-docker"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "terraform"
     directory: "/examples/runner-public"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "terraform"
     directory: "/examples/pre-registered"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "terraform"
     directory: "/examples/multi-region"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: gomod
     directory: /test
     schedule:
       interval: weekly
-    commit_message:
+    commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Description

Depdabot configuration contains [errors](https://github.com/npalm/terraform-aws-gitlab-runner/pull/636/checks?check_run_id=10498044900), commit_message -> commit-message

## Migrations required

NO

## Verification

CI