### PR TITLE
ci: add ChatOps command `/help`

### DIFF
--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -1,0 +1,32 @@
+---
+name: Execute SlashOps command
+
+on:
+  repository_dispatch:
+    types: 
+      - help-command
+
+jobs:
+  help-command:
+    name: "SlashOps: Help"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Choose maintainer
+        id: vars
+        run: |
+          maintainers=("npalm" "kayman-mk")
+          
+          RANDOM=$(date +%s)
+          
+          maintainer=${maintainers[ $RANDOM % ${#maintainers[@]} ]}
+
+          echo "maintainer=$maintainer" >> $GITHUB_OUTPUT
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            Hey there @${{ steps.vars.outputs.maintainer }}, could you please help @${{ github.event.client_payload.github.payload.comment.user.login }} out?

--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -14,19 +14,17 @@ jobs:
       - name: Choose maintainer
         id: vars
         run: |
-          maintainers=("npalm" "kayman-mk")
-          
-          RANDOM=$(date +%s)
-          
-          maintainer=${maintainers[ $RANDOM % ${#maintainers[@]} ]}
-
-          echo "maintainer=$maintainer" >> $GITHUB_OUTPUT
+          maintainer=$(cat CODEOWNERS | grep -oE "@[a-zA-Z0-9_-]+" | shuf -n 1)
+          echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
 
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: actions/github-script@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-          body: |
-            Hey there @${{ steps.vars.outputs.maintainer }}, could you please help @${{ github.event.client_payload.github.payload.comment.user.login }} out?
+          script: |
+            // adds a comment to the PR (there is the issue API, which works work PRs too)
+            github.rest.issues.createComment({
+              issue_number: context.payload.client_payload.github.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hey there ${{ steps.vars.outputs.maintainer }}, could you please help @${{ github.event.client_payload.github.payload.comment.user.login }} out?'
+            })

--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -1,5 +1,5 @@
 ---
-name: Execute SlashOps command
+name: Execute ChatOps command
 
 on:
   repository_dispatch:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   help-command:
-    name: "SlashOps: Help"
+    name: "ChathOps: Help"
     runs-on: ubuntu-latest
     steps:
       - name: Choose maintainer

--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   help-command:
-    name: "ChathOps: Help"
+    name: "ChatOps: /help"
     runs-on: ubuntu-latest
     steps:
       - name: Choose maintainer

--- a/.github/workflows/slash_ops_comment_dispatch.yml
+++ b/.github/workflows/slash_ops_comment_dispatch.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v3
         with:
-          # might need a PAT with public_repo scope
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           reactions: false

--- a/.github/workflows/slash_ops_comment_dispatch.yml
+++ b/.github/workflows/slash_ops_comment_dispatch.yml
@@ -1,0 +1,21 @@
+---
+name: PR commented
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  slash-command-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          # might need a PAT with public_repo scope
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          reactions: false
+          commands: |
+            help


### PR DESCRIPTION
## Description

This PR adds ChatOps commands for PRs. This makes it easy for new users to trigger some actions.

Supported commands:
- `/help`: Creates a comment in the PR which mentions one of the maintainers so he can help the user out

Needs #656 