### PR TITLE
fix: upgrade `docker-machine` to support new AWS regions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "docker_machine_download_url" {
 variable "docker_machine_version" {
   description = "By default docker_machine_download_url is used to set the docker machine version. Version of docker-machine. The version will be ingored once `docker_machine_download_url` is set."
   type        = string
-  default     = "0.16.2-gitlab.15"
+  default     = "use-newest-version-after-fix" # https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/merge_requests/99
 }
 
 variable "runners_name" {


### PR DESCRIPTION
## Description

Upgrades the project to the newest docker-machine to support new AWS regions, e.g. `eu-central-2` (Zurich).

Fixes #660 

## Migrations required

If `docker_machine_version` is set, consider to upgrade to the newest version as well, if you need the new AWS regions.

## Verification

- [ ] deployed to our QA system. Jobs are still processed
- [ ] used docker-machine and created one machine in `eu-central-2` successfully
