### PR TITLE
fix: bump docker machine version due to bug

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -915,3 +915,4 @@ variable "runner_extra_config" {
   type        = string
   default     = ""
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "docker_machine_download_url" {
 variable "docker_machine_version" {
   description = "By default docker_machine_download_url is used to set the docker machine version. Version of docker-machine. The version will be ingored once `docker_machine_download_url` is set."
   type        = string
-  default     = "0.16.2-gitlab.15"
+  default     = "0.16.2-gitlab.19"
 }
 
 variable "runners_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -915,4 +915,3 @@ variable "runner_extra_config" {
   type        = string
   default     = ""
 }
-


### PR DESCRIPTION
## Description

This PR updates the docker+machine to the newest version. The fixed bug relevant here is:

> With Docker 23.0.0 release (which happened today), installation of Docker doesn't create an /etc/docker directory
> anymore by default. It needs to be done manually.
> At the same time, Docker Machine's provisioning for some of the supported distributions assumes that it will be there by
> default and starts writing key/certificates files into that directory immediately. Which fails with
>
> `ERROR: tee: /etc/docker/ca.pem: No such file or directory`

This fixes https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/issues/98

## Migrations required

NO

## Verification

Updated in our environment which fixed the issue