### PR TITLE
chore: only install Docker machine when executor is docker+machine

### DIFF
--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -1,5 +1,3 @@
-# shellcheck disable=SC2154
-
 # Install jq if not exists
 if ! [ -x "$(command -v jq)" ]; then
   yum install jq -y

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2154
+
 # Install jq if not exists
 if ! [ -x "$(command -v jq)" ]; then
   yum install jq -y
@@ -5,7 +7,7 @@ fi
 
 # Provide the parent instance id in the spawned runner tags
 PARENT_INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .instanceId)
-PARENT_TAG="gitlab-runner-parent-id,$${PARENT_INSTANCE_ID}"
+PARENT_TAG="gitlab-runner-parent-id,$PARENT_INSTANCE_ID"
 
 mkdir -p /etc/gitlab-runner
 cat > /etc/gitlab-runner/config.toml <<- EOF
@@ -18,19 +20,19 @@ cat > /etc/gitlab-runner/runners_userdata.sh <<- EOF
 ${runners_userdata}
 EOF
 
-sed -i.bak s/__PARENT_TAG__/`echo $PARENT_TAG`/g /etc/gitlab-runner/config.toml
+sed -i.bak s/__PARENT_TAG__/$PARENT_TAG/g /etc/gitlab-runner/config.toml
 
 # fetch Runner token from SSM and validate it
 token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
 
 valid_token=true
-if [[ `echo $token` != "null" ]]
+if [[ "$token" != "null" ]]
 then
   valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
-  [[ `echo $valid_token_response` != "200" ]] && valid_token=false
+  [[ "$valid_token_response" != "200" ]] && valid_token=false
 fi
 
-if [[ `echo ${runners_token}` == "__REPLACED_BY_USER_DATA__" && `echo $token` == "null" ]] || [[ `echo $valid_token` == "false" ]]
+if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
 then
   token=$(curl --request POST -L "${runners_gitlab_url}/api/v4/runners" \
     --form "token=${gitlab_runner_registration_token}" \
@@ -44,21 +46,21 @@ then
   aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --value="$token" --region "${secure_parameter_store_region}"
 fi
 
-sed -i.bak s/__REPLACED_BY_USER_DATA__/`echo $token`/g /etc/gitlab-runner/config.toml
+sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
 
 ssm_sentry_dsn=$(aws ssm get-parameters --names "${secure_parameter_store_runner_sentry_dsn}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
-if [[ `echo ${sentry_dsn}` == "__SENTRY_DSN_REPLACED_BY_USER_DATA__" && `echo $ssm_sentry_dsn` == "null" ]]
+if [[ "${sentry_dsn}" == "__SENTRY_DSN_REPLACED_BY_USER_DATA__" && "$ssm_sentry_dsn" == "null" ]]
 then
   ssm_sentry_dsn=""
 fi
 
 # For those of you wondering why commas are used in the sed below instead of forward slashes, see https://stackoverflow.com/a/16778711/13169919
 # It is because the Sentry DSN contains forward slashes as it is an URL so it would break out of the sed command with forward slashes as delimiters :)
-sed -i.bak s,__SENTRY_DSN_REPLACED_BY_USER_DATA__,`echo $ssm_sentry_dsn`,g /etc/gitlab-runner/config.toml
+sed -i.bak s,__SENTRY_DSN_REPLACED_BY_USER_DATA__,"$ssm_sentry_dsn",g /etc/gitlab-runner/config.toml
 
 ${pre_install}
 
-if [[ `echo ${runners_executor}` == "docker" ]]
+if [[ "${runners_executor}" == "docker" ]]
 then
   echo 'installing docker'
   if grep -q ':2$' /etc/system-release-cpe  ; then
@@ -74,7 +76,7 @@ then
   fi
 fi
 
-if [[ `echo ${runners_install_amazon_ecr_credential_helper}` == "true" ]]
+if [[ "${runners_install_amazon_ecr_credential_helper}" == "true" ]]
 then
   yum install amazon-ecr-credential-helper -y
 fi
@@ -85,27 +87,33 @@ then
   yum install gitlab-runner-${gitlab_runner_version} -y
 fi
 
-if [[ `echo ${docker_machine_download_url}` == "" ]]
+if [[ "${runners_executor}" == "docker+machine" ]]
 then
-  curl --fail --retry 6 -L https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v${docker_machine_version}/downloads/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine
-else
-  curl --fail --retry 6 -L ${docker_machine_download_url} >/tmp/docker-machine
+  if [[ "${docker_machine_download_url}" == "" ]]
+  then
+    echo "Installing Docker Machine using preconfigured URL"
+    curl --fail --retry 6 -L https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v${docker_machine_version}/downloads/docker-machine-"$(uname -s)"-"$(uname -m)" >/tmp/docker-machine
+  else
+    echo "Installing Docker Machine using custom URL"
+    curl --fail --retry 6 -L ${docker_machine_download_url} >/tmp/docker-machine
+  fi
+
+  chmod +x /tmp/docker-machine && \
+    mv /tmp/docker-machine /usr/local/bin/docker-machine && \
+    ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine
+  docker-machine --version
+
+  # Create a dummy machine so that the cert is generated properly
+  # See: https://gitlab.com/gitlab-org/gitlab-runner/issues/3676
+  # See: https://github.com/docker/machine/issues/3845#issuecomment-280389178
+  export USER=root
+  export HOME=/root
+  docker-machine create --driver none --url localhost dummy-machine
+  docker-machine rm -y dummy-machine
+  unset HOME
+  unset USER
+
 fi
-
-chmod +x /tmp/docker-machine && \
-  mv /tmp/docker-machine /usr/local/bin/docker-machine && \
-  ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine
-docker-machine --version
-
-# Create a dummy machine so that the cert is generated properly
-# See: https://gitlab.com/gitlab-org/gitlab-runner/issues/3676
-# See: https://github.com/docker/machine/issues/3845#issuecomment-280389178
-export USER=root
-export HOME=/root
-docker-machine create --driver none --url localhost dummy-machine
-docker-machine rm -y dummy-machine
-unset HOME
-unset USER
 
 # A small script to remove this runner from being registered with Gitlab.
 cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,11 @@ variable "runners_executor" {
   description = "The executor to use. Currently supports `docker+machine` or `docker`."
   type        = string
   default     = "docker+machine"
+
+  validation {
+    condition = contains(["docker+machine", "docker"], var.runners_executor)
+    error_message = "The executor currently supports `docker+machine` or `docker`."
+  }
 }
 
 variable "runners_install_amazon_ecr_credential_helper" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,7 @@ variable "runners_executor" {
   default     = "docker+machine"
 
   validation {
-    condition = contains(["docker+machine", "docker"], var.runners_executor)
+    condition     = contains(["docker+machine", "docker"], var.runners_executor)
     error_message = "The executor currently supports `docker+machine` or `docker`."
   }
 }


### PR DESCRIPTION
## Description

Only download and install Docker Machine binary when executor is `docker+machine`. This prevent an unnecessary download of the binary when the executor is `docker`.

Boy scout: removed all the "\`echo $[variable]\`" instances, seems unnecessary and spawns a subshell for each of these calls.

## Migrations required

NO

## Verification

- [x] Configure `docker+machine` executor: binary is present on Manager instance and machines are created
```bash
$ which docker-machine
/usr/local/bin/docker-machine

```

- [x] Configure `docker` executor: `docker` is present on Manager instance while `docker-machine` is not:
```bash
$ which docker && which docker-machine
/usr/bin/docker
which: no docker-machine in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin)
```

- [x] Configure `shell` executor: Terraform plan fails with:
```bash
❯ tfplan
╷
│ Error: Invalid value for variable
│ 
│   on gitlab_runner.tf line 52, in module "runner":
│   52:   runners_executor = "shell"
│     ├────────────────
│     │ var.runners_executor is "shell"
│ 
│ The executor currently supports `docker+machine` or `docker`.
│ 
│ This was checked by the validation rule at .terraform/modules/runner/variables.tf:138,3-13.
╵
```

- [x]  `userdata` template renders correctly:

<details>
Changes to Outputs:
  + userdata = <<-EOT
        #!/bin/bash -e
        exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
        
        if [[ $(echo true) == true ]]; then
          set -x
        fi
        
        # Add current hostname to hosts file
        tee /etc/hosts <<EOL
        127.0.0.1   localhost localhost.localdomain $(hostname)
        EOL
        
        token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
        
        
        
        for i in {1..7}; do
          echo "Attempt: ---- " $i
          yum -y update && break || sleep 60
        done
        
        
        echo 'installing additional software for logging'
        # installing in a loop to ensure the cli is installed.
        for i in {1..7}
        do
          echo "Attempt: ---- " $i
          yum install -y aws-cli awslogs jq && break || sleep 60
        done
        
        # Inject the CloudWatch Logs configuration file contents
        cat > /etc/awslogs/awslogs.conf <<- EOF
        [general]
        state_file = /var/lib/awslogs/agent-state
        
        [/var/log/dmesg]
        file = /var/log/dmesg
        log_stream_name = {instanceId}/dmesg
        log_group_name = [GROUP NAME]
        initial_position = start_of_file
        
        [/var/log/messages]
        file = /var/log/messages
        log_stream_name = {instanceId}/messages
        log_group_name = [GROUP NAME]
        datetime_format = %b %d %H:%M:%S
        initial_position = start_of_file
        
        [/var/log/user-data.log]
        file = /var/log/user-data.log
        log_stream_name = {instanceId}/user-data
        log_group_name = [GROUP NAME]
        initial_position = start_of_file
        
        EOF
        
        # Set the region to send CloudWatch Logs data to (the region where the instance is located)
        region=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
        sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
        
        # Replace instance id.
        instanceId=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .instanceId)
        sed -i -e "s/{instanceId}/$instanceId/g" /etc/awslogs/awslogs.conf
        
        if grep -q ':2$' /etc/system-release-cpe  ; then
          # AWS Linux 2 renamed the awslogs service to awslogsd and uses systemd
          systemctl enable awslogsd
          systemctl start awslogsd
        else
          service awslogs start
          chkconfig awslogs on
        fi
        
        
        # shellcheck disable=SC2154
        
        # Install jq if not exists
        if ! [ -x "$(command -v jq)" ]; then
          yum install jq -y
        fi
        
        # Provide the parent instance id in the spawned runner tags
        PARENT_INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .instanceId)
        PARENT_TAG="gitlab-runner-parent-id,$PARENT_INSTANCE_ID"
        
        mkdir -p /etc/gitlab-runner
        cat > /etc/gitlab-runner/config.toml <<- EOF
        
        concurrent = 20
        check_interval = 3
        sentry_dsn = "__SENTRY_DSN_REPLACED_BY_USER_DATA__"
        log_format = "json"
        listen_address = ""
        
        [[runners]]
          name = "[NAME]"
          url = "https://gitlab.com/"
          clone_url = ""
          token = "__REPLACED_BY_USER_DATA__"
          executor = "docker+machine"
          environment = ["DOCKER_DRIVER=overlay2"]
          pre_build_script = ""
          post_build_script = ""
          pre_clone_script = ""
          request_concurrency = 1
          output_limit = 4096
          limit = 0
          [runners.docker]
            tls_verify = false
            image = "docker:stable"
            privileged = true
            disable_cache = false
            volumes = ["/cache","/certs/client","/builds"]
            extra_hosts = []
            shm_size = 0
            pull_policy = ["always"]
            runtime = ""
            helper_image = ""
            
          [runners.docker.tmpfs]
            
          [runners.docker.services_tmpfs]
            
          [runners.cache]
            Type = "s3"
            Shared = true
            [runners.cache.s3]
              AuthenticationType = "iam"
              ServerAddress = "s3.amazonaws.com"
              BucketName = ""
              BucketLocation = "us-east-20"
              Insecure = false
          [runners.machine]
            IdleCount = 0
            IdleTime = 600
            MaxBuilds = 10
            MachineDriver = "amazonec2"
            MachineName = "[name]-de-%s"
            MachineOptions = [
              [OPTIONS]
            ]
        
        
        
        
        EOF
        
        cat > /etc/gitlab-runner/runners_userdata.sh <<- EOF
        
        EOF
        
        sed -i.bak s/__PARENT_TAG__/$PARENT_TAG/g /etc/gitlab-runner/config.toml
        
        # fetch Runner token from SSM and validate it
        token=$(aws ssm get-parameters --names "[SSM_PATH]" --with-decryption --region "us-east-2" | jq -r ".Parameters | .[0] | .Value")
        
        valid_token=true
        if [[ "$token" != "null" ]]
        then
          valid_token_response=$(curl -s -o /dev/null -w "%{response_code}" --request POST -L "https://gitlab.com//api/v4/runners/verify" --form "token=$token" )
          [[ "$valid_token_response" != "200" ]] && valid_token=false
        fi
        
        if [[ "__REPLACED_BY_USER_DATA__" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
        then
          token=$(curl --request POST -L "https://gitlab.com//api/v4/runners" \
            --form "token=[TOKEN]" \
            --form "tag_list=docker_spot_runner" \
            --form "description=runner public - auto" \
            --form "locked=false" \
            --form "run_untagged=true" \
            --form "maximum_timeout=3600" \
            --form "access_level=not_protected" \
            | jq -r .token)
          aws ssm put-parameter --overwrite --type SecureString  --name "[TOKEN_PATH]" --value="$token" --region "us-east-26"
        fi
        
        sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
        
        ssm_sentry_dsn=$(aws ssm get-parameters --names "[SENTRY_PATH]" --with-decryption --region "us-east-2" | jq -r ".Parameters | .[0] | .Value")
        if [[ "__SENTRY_DSN_REPLACED_BY_USER_DATA__" == "__SENTRY_DSN_REPLACED_BY_USER_DATA__" && "$ssm_sentry_dsn" == "null" ]]
        then
          ssm_sentry_dsn=""
        fi
        
        # For those of you wondering why commas are used in the sed below instead of forward slashes, see https://stackoverflow.com/a/16778711/13169919
        # It is because the Sentry DSN contains forward slashes as it is an URL so it would break out of the sed command with forward slashes as delimiters :)
        sed -i.bak s,__SENTRY_DSN_REPLACED_BY_USER_DATA__,"$ssm_sentry_dsn",g /etc/gitlab-runner/config.toml
        
        
        
        if [[ "docker+machine" == "docker" ]]
        then
          echo 'installing docker'
          if grep -q ':2$' /etc/system-release-cpe  ; then
            # AWS Linux 2 provides docker via extras only and uses systemd (https://aws.amazon.com/amazon-linux-2/release-notes/)
            amazon-linux-extras install docker
            usermod -a -G docker ec2-user
            systemctl enable docker
            systemctl start docker
          else
            yum install docker -y
            usermod -a -G docker ec2-user
            service docker start
          fi
        fi
        
        if [[ "false" == "true" ]]
        then
          yum install amazon-ecr-credential-helper -y
        fi
        
        if ! ( rpm -q gitlab-runner >/dev/null )
        then
          curl --fail --retry 6 -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | bash
          yum install gitlab-runner-15.8.2 -y
        fi
        
        if [[ "docker+machine" == "docker+machine" ]]
        then
          if [[ "https://arr-cki-prod-docker-machine.s3.amazonaws.com/v0.16.2-gitlab.19-cki.2/docker-machine-Linux-x86_64" == "" ]]
          then
            echo "Installing Docker Machine using preconfigured URL"
            curl --fail --retry 6 -L https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.19/downloads/docker-machine-"$(uname -s)"-"$(uname -m)" >/tmp/docker-machine
          else
            echo "Installing Docker Machine using custom URL"
            curl --fail --retry 6 -L https://arr-cki-prod-docker-machine.s3.amazonaws.com/v0.16.2-gitlab.19-cki.2/docker-machine-Linux-x86_64 >/tmp/docker-machine
          fi
        
          chmod +x /tmp/docker-machine && \
            mv /tmp/docker-machine /usr/local/bin/docker-machine && \
            ln -s /usr/local/bin/docker-machine /usr/bin/docker-machine
          docker-machine --version
        
          # Create a dummy machine so that the cert is generated properly
          # See: https://gitlab.com/gitlab-org/gitlab-runner/issues/3676
          # See: https://github.com/docker/machine/issues/3845#issuecomment-280389178
          export USER=root
          export HOME=/root
          docker-machine create --driver none --url localhost dummy-machine
          docker-machine rm -y dummy-machine
          unset HOME
          unset USER
        
        fi
        
        # A small script to remove this runner from being registered with Gitlab.
        cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration
        #!/bin/bash
        # chkconfig: 1356 99 03
        # description: cleans up gitlab runner key
        # processname: remove_runner_key
        #              /etc/rc.d/init.d/remove_gitlab_registration
        lockfile=/var/lock/subsys/remove_gitlab_registration
        
        # This lockfile is necessary so that we'll run the cleanup later.
        start() {
            logger "Setting up Runner Removal Lockfile"
            touch \$lockfile
        }
        
        # Overwrite token in SSM with null and remove runner from Gitlab
        stop() {
            logger "Removing Gitlab Runner Token"
            aws ssm put-parameter --overwrite --type SecureString  --name "[SSM_TOKEN_PATH]" --region "us-east-2" --value="null" 2>&1 | logger &
            curl -sS --request DELETE "https://gitlab.com//api/v4/runners" --form "token=$token" 2>&1 | logger &
            retval=\$?
            rm -f \$lockfile
            return \$retval
        }
        
        # Map these to start just to be redunant.
        # We don't want to run Stop outside of shutdown.
        restart() {
          start
        }
        reload() {
          start
        }
        
        # Do nothing - there's no status.
        status() {
          :
        }
        
        case "\$1" in
            start)
                \$1
                ;;
            stop)
                \$1
                ;;
            restart)
                \$1
                ;;
            status)
                \$1
                ;;
            *)
                echo "Usage: \$0 {start|stop|status|restart}"
                exit 2
                ;;
        esac
        REM
        
        chmod a+x /etc/init.d/remove_gitlab_registration
        
        # Use chkconfig to link into the runlevel 0 (shutdown) directories
        # This adds "start" scripts to levels 1,3,5, and 6, and a "stop" to the others.
        # This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
        chkconfig --add remove_gitlab_registration
        
        # As noted above, this does nothing more than make the lockfile.
        service remove_gitlab_registration start
        
        
        
        service gitlab-runner restart
        chkconfig gitlab-runner on
        
        
        
    EOT
</details>
