### PR TITLE
feat: add support for timezone in AWS autoscaling config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,7 @@ resource "aws_autoscaling_schedule" "scale_in" {
   autoscaling_group_name = aws_autoscaling_group.gitlab_runner_instance.name
   scheduled_action_name  = "scale_in-${aws_autoscaling_group.gitlab_runner_instance.name}"
   recurrence             = var.schedule_config["scale_in_recurrence"]
+  time_zone              = try(var.schedule_config["scale_in_time_zone"], "Etc/UTC")
   min_size               = try(var.schedule_config["scale_in_min_size"], var.schedule_config["scale_in_count"])
   desired_capacity       = try(var.schedule_config["scale_in_desired_capacity"], var.schedule_config["scale_in_count"])
   max_size               = try(var.schedule_config["scale_in_max_size"], var.schedule_config["scale_in_count"])
@@ -211,6 +212,7 @@ resource "aws_autoscaling_schedule" "scale_out" {
   autoscaling_group_name = aws_autoscaling_group.gitlab_runner_instance.name
   scheduled_action_name  = "scale_out-${aws_autoscaling_group.gitlab_runner_instance.name}"
   recurrence             = var.schedule_config["scale_out_recurrence"]
+  time_zone              = try(var.schedule_config["scale_out_time_zone"], "Etc/UTC")
   min_size               = try(var.schedule_config["scale_out_min_size"], var.schedule_config["scale_out_count"])
   desired_capacity       = try(var.schedule_config["scale_out_desired_capacity"], var.schedule_config["scale_out_count"])
   max_size               = try(var.schedule_config["scale_out_max_size"], var.schedule_config["scale_out_count"])

--- a/variables.tf
+++ b/variables.tf
@@ -673,13 +673,13 @@ variable "schedule_config" {
     # Configure optional scale_out scheduled action
     scale_out_recurrence = "0 8 * * 1-5"
     scale_out_count      = 1 # Default for min_size, desired_capacity and max_size
-    scale_out_timezone   = "Etc/UTC"
+    scale_out_time_zone  = "Etc/UTC"
     # Override using: scale_out_min_size, scale_out_desired_capacity, scale_out_max_size
 
     # Configure optional scale_in scheduled action
     scale_in_recurrence = "0 18 * * 1-5"
     scale_in_count      = 0 # Default for min_size, desired_capacity and max_size
-    scale_in_timezone   = "Etc/UTC"
+    scale_in_time_zone  = "Etc/UTC"
     # Override using: scale_out_min_size, scale_out_desired_capacity, scale_out_max_size
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -673,11 +673,13 @@ variable "schedule_config" {
     # Configure optional scale_out scheduled action
     scale_out_recurrence = "0 8 * * 1-5"
     scale_out_count      = 1 # Default for min_size, desired_capacity and max_size
+    scale_out_timezone   = "Etc/UTC"
     # Override using: scale_out_min_size, scale_out_desired_capacity, scale_out_max_size
 
     # Configure optional scale_in scheduled action
     scale_in_recurrence = "0 18 * * 1-5"
     scale_in_count      = 0 # Default for min_size, desired_capacity and max_size
+    scale_in_timezone   = "Etc/UTC"
     # Override using: scale_out_min_size, scale_out_desired_capacity, scale_out_max_size
   }
 }


### PR DESCRIPTION
## Description

Adds supports for setting timezone for the AWS autoscaling configuration.

## Migrations required

NO - Terraform will detect a change to the timezone attribute, but `Etc/UTC` should be the default anyway.

## Verification

Changing the timezone:

```hcl
enable_schedule = true
  schedule_config = {
    scale_out_recurrence = "0 5 * * MON-FRI"
    scale_out_count      = 1
    scale_out_time_zone  = "Europe/Amsterdam"

    scale_in_recurrence = "0 19 * * *"
    scale_in_count      = 0
    scale_in_time_zone  = "Europe/Amsterdam"
  }
```

plan:

![image](https://user-images.githubusercontent.com/17970041/220947359-0429411e-108c-4ef8-a6f1-ef0d62303225.png)

And result:

![image](https://user-images.githubusercontent.com/17970041/220947833-aa1a2703-8735-4c28-a1ef-eb78b4424ca4.png)

Defaults:

```hcl
enable_schedule = true
  schedule_config = {
    scale_out_recurrence = "0 5 * * MON-FRI"
    scale_out_count      = 1
    # scale_out_time_zone  = "Europe/Amsterdam"

    scale_in_recurrence = "0 19 * * *"
    scale_in_count      = 0
    # scale_in_time_zone  = "Europe/Amsterdam"
  }
```

Plan:

![image](https://user-images.githubusercontent.com/17970041/220949843-5b9d092a-9e9d-454f-b73b-dd8d69c2a5fc.png)

And result:

![image](https://user-images.githubusercontent.com/17970041/220948882-c45aefac-05dc-4499-8d98-08c050fd091d.png)






