### PR TITLE
fix: set correct lifecycle prefix for shared cache

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -327,8 +327,10 @@ module "cache" {
   cache_bucket_set_random_suffix       = var.cache_bucket_set_random_suffix
   cache_bucket_versioning              = var.cache_bucket_versioning
   cache_expiration_days                = var.cache_expiration_days
+  cache_lifecycle_prefix               = var.cache_shared ? "project/" : "runner/"
   cache_logging_bucket                 = var.cache_logging_bucket
   cache_logging_bucket_prefix          = var.cache_logging_bucket_prefix
+
 
   kms_key_id = local.kms_key
 

--- a/main.tf
+++ b/main.tf
@@ -331,7 +331,6 @@ module "cache" {
   cache_logging_bucket                 = var.cache_logging_bucket
   cache_logging_bucket_prefix          = var.cache_logging_bucket_prefix
 
-
   kms_key_id = local.kms_key
 
   name_iam_objects = local.name_iam_objects


### PR DESCRIPTION
## Description

Sets the lifecycle prefix correctly based on whether the cache is shared or not.
For more context see validation in #539.

## Migrations required

NO - users of a shared cache should finally get a correct lifecycle prefix! 🚀 

## Verification

```hcl
cache_shared = false
```

Result:

![image](https://user-images.githubusercontent.com/17970041/221151688-a6b15168-8b42-4c54-968b-b74858b5d67e.png)


```hcl
cache_shared = true
```

Result:

![image](https://user-images.githubusercontent.com/17970041/221152160-628df813-7a18-49e1-9b6d-3e04f5dca723.png)

Closes #539
