### PR TITLE
fix: eip race condition when updating ASG

### DIFF
--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -161,6 +161,20 @@ data "aws_iam_policy_document" "spot_request_housekeeping" {
   }
 }
 
+data "aws_iam_policy_document" "eip_cleanup" {
+  statement {
+    sid = "EIPCleanup"
+
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeAddresses",
+      "ec2:DisassociateAddress",
+      "ec2:ReleaseAddress"
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_policy" "lambda" {
   name   = "${var.name_iam_objects}-${var.name}-lambda"
   path   = "/"
@@ -185,6 +199,19 @@ resource "aws_iam_policy" "spot_request_housekeeping" {
 resource "aws_iam_role_policy_attachment" "spot_request_housekeeping" {
   role       = aws_iam_role.lambda.name
   policy_arn = aws_iam_policy.spot_request_housekeeping.arn
+}
+
+resource "aws_iam_policy" "eip_cleanup" {
+  name   = "${var.name_iam_objects}-${var.name}-eip-cleanup"
+  path   = "/"
+  policy = data.aws_iam_policy_document.eip_cleanup.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eip_cleanup" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.eip_cleanup.arn
 }
 
 resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access_execution_role" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,11 +43,6 @@ output "runner_sg_id" {
   value       = var.runner_worker.type == "docker-autoscaler" ? aws_security_group.docker_autoscaler[0].id : (var.runner_worker.type == "docker+machine" ? aws_security_group.docker_machine[0].id : null)
 }
 
-output "runner_eip" {
-  description = "EIP of the Gitlab Runner"
-  value       = length(aws_eip.gitlab_runner) > 0 ? aws_eip.gitlab_runner[0].public_ip : null
-}
-
 output "runner_launch_template_name" {
   description = "The name of the runner's launch template."
   value       = aws_launch_template.gitlab_runner_instance.name

--- a/policies/instance-docker-autoscaler-policy.json
+++ b/policies/instance-docker-autoscaler-policy.json
@@ -1,34 +1,36 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
-            ],
-            "Resource": "${autoscaler_asg_arn}"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "ec2:DescribeInstances"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:GetPasswordData",
-                "ec2-instance-connect:SendSSHPublicKey"
-            ],
-            "Resource": "arn:${partition}:ec2:${aws_region}:*:instance/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:ResourceTag/aws:autoscaling:groupName": "${autoscaler_asg_name}"
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
+      ],
+      "Resource": "${autoscaler_asg_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "ec2:DescribeInstances",
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeLifecycleHooks"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:GetPasswordData",
+        "ec2-instance-connect:SendSSHPublicKey"
+      ],
+      "Resource": "arn:${partition}:ec2:${aws_region}:*:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/aws:autoscaling:groupName": "${autoscaler_asg_name}"
         }
-    ]
+      }
+    }
+  ]
 }

--- a/policies/instance-eip.json
+++ b/policies/instance-eip.json
@@ -4,7 +4,11 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
+                "ec2:DisassociateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:CreateTags",
                 "ec2:Describe*"
             ],
             "Resource": "*"

--- a/template/eip.tftpl
+++ b/template/eip.tftpl
@@ -1,10 +1,67 @@
-echo 'installing additional software for assigning EIP'
+echo 'Setting up dynamic EIP management'
 
-yum install python3 -y
-curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
-python3 get-pip.py --user
-export PATH=~/.local/bin:$PATH
+# Get instance metadata (token already available from user-data)
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
 
-pip install aws-ec2-assign-elastic-ip
-export AWS_DEFAULT_REGION=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
-/usr/local/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}
+export AWS_DEFAULT_REGION=$REGION
+
+# Create directory for storing EIP allocation ID
+mkdir -p /var/lib/ec2-eip
+
+max_retries=5
+retry_count=0
+wait_time=10
+
+while [ $retry_count -lt $max_retries ]; do
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Attempting to allocate EIP (attempt $((retry_count + 1))/$max_retries)"
+
+    EIP_RESULT=$(aws ec2 allocate-address --domain vpc --query 'AllocationId' --output text 2>&1)
+    EIP_EXIT_CODE=$?
+
+    if [ $EIP_EXIT_CODE -eq 0 ] && [[ "$EIP_RESULT" =~ ^eipalloc- ]]; then
+        ALLOCATION_ID="$EIP_RESULT"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Successfully allocated EIP with allocation ID: $ALLOCATION_ID"
+
+        TAG_RESULT=$(aws ec2 create-tags --resources "$ALLOCATION_ID" --tags ${eip_tags} 2>&1)
+        TAG_EXIT_CODE=$?
+        if [ $TAG_EXIT_CODE -eq 0 ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Successfully tagged EIP $ALLOCATION_ID"
+        else
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Warning: Failed to tag EIP $ALLOCATION_ID: $TAG_RESULT"
+        fi
+
+        ASSOC_RESULT=$(aws ec2 associate-address --instance-id "$INSTANCE_ID" --allocation-id "$ALLOCATION_ID" 2>&1)
+        ASSOC_EXIT_CODE=$?
+        if [ $ASSOC_EXIT_CODE -eq 0 ]; then
+            echo "$ALLOCATION_ID" > /var/lib/ec2-eip/allocation-id
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: EIP allocation completed successfully"
+            break
+        else
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Error: Failed to associate EIP $ALLOCATION_ID with instance $INSTANCE_ID: $ASSOC_RESULT"
+
+            # Clean up the allocated EIP if association failed
+            CLEANUP_RESULT=$(aws ec2 release-address --allocation-id "$ALLOCATION_ID" 2>&1)
+            if [ $? -eq 0 ]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Successfully cleaned up failed EIP allocation"
+            else
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Warning: Failed to cleanup EIP $ALLOCATION_ID: $CLEANUP_RESULT"
+            fi
+        fi
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Error: Failed to allocate EIP (exit code: $EIP_EXIT_CODE): $EIP_RESULT"
+    fi
+
+    retry_count=$((retry_count + 1))
+    if [ $retry_count -lt $max_retries ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Waiting $wait_time seconds before retry..."
+        sleep $wait_time
+        wait_time=$((wait_time * 2))
+    fi
+done
+
+if [ $retry_count -eq $max_retries ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: Error: Failed to allocate and associate EIP after $max_retries attempts"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-ALLOCATION: EIP allocation failed - GitLab Runner will not have an EIP associated"
+    exit 1
+fi

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -325,6 +325,84 @@ imds_token=$(curl -sSf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aw
 instance_id=$(curl -sSf -H "X-aws-ec2-metadata-token: $imds_token" "http://169.254.169.254/latest/meta-data/instance-id")
 region=$(curl -sSf -H "X-aws-ec2-metadata-token: $imds_token" "http://169.254.169.254/latest/meta-data/placement/region")
 
+%{ if use_eip }
+release_eip() {
+    # File generated in eip.tftpl
+    allocation_id_file="/var/lib/ec2-eip/allocation-id"
+    if [ -f "$allocation_id_file" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Releasing EIP before lifecycle completion..."
+        allocation_id=$(cat "$allocation_id_file")
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Found stored EIP allocation ID: $allocation_id"
+
+        # Get current association to verify it's ours
+        associated_instance=$(aws --region $region ec2 describe-addresses --allocation-ids "$allocation_id" --query 'Addresses[0].InstanceId' --output text 2>/dev/null || echo "")
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: EIP association check: EIP=$allocation_id, CurrentInstance=$instance_id, AssociatedInstance='$associated_instance'"
+
+        if [ "$associated_instance" = "$instance_id" ] || [ "$associated_instance" = "None" ] || [ -z "$associated_instance" ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Disassociating EIP $allocation_id"
+            association_id=$(aws --region $region ec2 describe-addresses --allocation-ids "$allocation_id" --query 'Addresses[0].AssociationId' --output text 2>/dev/null)
+            if [ "$association_id" != "None" ] && [ -n "$association_id" ]; then
+                DISASSOC_RESULT=$(aws --region $region ec2 disassociate-address --association-id "$association_id" 2>&1)
+            else
+                DISASSOC_RESULT="EIP not associated"
+            fi
+            DISASSOC_EXIT_CODE=$?
+            if [ $DISASSOC_EXIT_CODE -ne 0 ]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Warning: Failed to disassociate EIP (exit code: $DISASSOC_EXIT_CODE): $DISASSOC_RESULT"
+            fi
+
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Releasing EIP $allocation_id"
+            RELEASE_RESULT=$(aws --region $region ec2 release-address --allocation-id "$allocation_id" 2>&1)
+            RELEASE_EXIT_CODE=$?
+            if [ $RELEASE_EXIT_CODE -eq 0 ]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Successfully released EIP $allocation_id"
+                rm -f "$allocation_id_file"
+            else
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Error: Failed to release EIP $allocation_id (exit code: $RELEASE_EXIT_CODE): $RELEASE_RESULT"
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Warning: Failed to release EIP $allocation_id, continuing with lifecycle completion"
+            fi
+        else
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Warning: EIP $allocation_id is associated with different instance $associated_instance, not releasing"
+            rm -f "$allocation_id_file"  # Clean up stale file
+        fi
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: No stored EIP allocation ID found, checking for associated EIP"
+
+        # Try to find EIP associated with this instance
+        allocation_id=$(aws --region $region ec2 describe-addresses --filters "Name=instance-id,Values=$instance_id" --query 'Addresses[0].AllocationId' --output text 2>/dev/null || echo "None")
+
+        if [ "$allocation_id" != "None" ] && [ -n "$allocation_id" ]; then
+            echo "Found EIP $allocation_id associated with this instance"
+
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Disassociating EIP $allocation_id"
+            # Get association ID first, then disassociate
+            association_id=$(aws --region $region ec2 describe-addresses --allocation-ids "$allocation_id" --query 'Addresses[0].AssociationId' --output text 2>/dev/null)
+            if [ "$association_id" != "None" ] && [ -n "$association_id" ]; then
+                DISASSOC_RESULT=$(aws --region $region ec2 disassociate-address --association-id "$association_id" 2>&1)
+            else
+                DISASSOC_RESULT="EIP not associated"
+            fi
+            DISASSOC_EXIT_CODE=$?
+            if [ $DISASSOC_EXIT_CODE -ne 0 ]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Warning: Failed to disassociate EIP (exit code: $DISASSOC_EXIT_CODE): $DISASSOC_RESULT"
+            fi
+
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Releasing EIP $allocation_id"
+            RELEASE_RESULT=$(aws --region $region ec2 release-address --allocation-id "$allocation_id" 2>&1)
+            RELEASE_EXIT_CODE=$?
+            if [ $RELEASE_EXIT_CODE -eq 0 ]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Successfully released EIP $allocation_id"
+            else
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Error: Failed to release EIP $allocation_id (exit code: $RELEASE_EXIT_CODE): $RELEASE_RESULT"
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] EIP-RELEASE: Warning: Failed to release EIP $allocation_id, continuing with lifecycle completion"
+            fi
+        else
+            echo "No EIP found associated with this instance"
+        fi
+    fi
+}
+%{ endif }
+
 # Function to send complete-lifecycle-action
 send_complete_lifecycle_action() {
     echo "Sending complete-lifecycle-action for instance $instance_id..."
@@ -382,6 +460,11 @@ monitor_process() {
         status=$(systemctl is-active gitlab-runner.service)
         if [ "$status" = "inactive" ] || [ "$status" = "failed" ]; then
           echo "GitLab Runner service $status. Proceeding with cleanup."
+
+%{ if use_eip }
+          release_eip
+%{ endif }
+
           send_complete_lifecycle_action
         else
           echo "GitLab Runner Service still running, sleeping..."


### PR DESCRIPTION
## Description

Add a second EIP, when we decide to use EIP for the manager. This way, when we update the ASG, a free EIP is available to pick by the `aws-ec2-assign-elastic-ip` tool.

This fix the rolling update, and allow for a smoother transition (instead of trying to work around the removing of the EIP association), and breaking the availability of the runner.

The caveats is that we require two EIP for this use case, but I guess it's okay, as long the user is aware of it.

## Migrations required

No

## Verification

Running a deployment with a runner instance using an EIP, then applying a configuration change for this (like changing the type, or an AMI update).

```
runner_instance = {
  use_eip  = true
}
```

The second runner is starting correctly, and get an EIP associated.

## Alternative

To avoid using two EIP ressources, we may add some more logic in the `template/eip.tftpl` in order to check the EIP availability, and do a switchover if it is already associated to an existing running instance. The issue is that the runner would still be unavailable in the meantime, on Gitlab side, because it will still running the rest of the cloud init script, and won't be able to keep the communication.
I'm open to the discussion about this, but having two EIP is more reliable I think.