### PR TITLE
chore: change deprecated aws_region "name" attribute

### DIFF
--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "lambda" {
     actions = [
       "ec2:TerminateInstances"
     ]
-    resources = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:instance/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:instance/*"]
     condition {
       test     = "StringLike"
       variable = "ec2:ResourceTag/gitlab-runner-parent-id"


### PR DESCRIPTION
## Description

Update the name attribute by region in the aws_region resource, for compatibility with  aws provider 6.0+

## Migrations required

No

## Notes

This PR resolves the Issue [#1334](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/1334).

Need a tag creation to be able to use the updates.


Thank you

