### PR TITLE
fix: use unique output file name for the lambda function

### DIFF
--- a/modules/terminate-agent-hook/main.tf
+++ b/modules/terminate-agent-hook/main.tf
@@ -11,7 +11,7 @@ locals {
 data "archive_file" "terminate_runner_instances_lambda" {
   type             = "zip"
   source_file      = "${path.module}/lambda/terminate_runners.py"
-  output_path      = "${path.module}/builds/terminate-agent-hook/${var.environment}/${var.name}/lambda_function_${local.source_sha256}.zip"
+  output_path      = "${path.module}/builds/${var.environment}/${var.name}/terminate-agent-hook_${local.source_sha256}.zip"
   output_file_mode = "0666"
 }
 


### PR DESCRIPTION
## Description

As described in #1333 we need a unique name for the lambda zip file if the project is built in parallel. Otherwise the file is overwritten by the other process.

To make the name unique, we use the resource prefix for the AWS resources we create. They have to be unique per definition, so our file name will be unique as well.

Closes #1333 