### PR TITLE
docs: clarify manual registration process for GitLab Runner

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ Common pitfalls are documented in [pitfalls.md](pitfalls.md).
 
 The examples are configured with defaults that should work in general. The examples are in general configured for the
 region Ireland `eu-west-1`. The only parameter that needs to be provided is the name of a SSM parameter holding the Runner
-registration token and the URL of your GitLab instance. The Runner token is created in GitLab during the Runner registration process.
+registration token and the URL of your GitLab instance. The Runner token is created in GitLab manually during the Runner registration process.
 Create a file `terraform.tfvars` and put the Runner registration token in the SSM parameter.
 
 ```hcl
@@ -17,10 +17,6 @@ gitlab_url   = "https://my.gitlab.instance/"
 The base image used to host the GitLab Runner agent is the latest available Amazon Linux 2 HVM EBS AMI. In previous versions of
 this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest
 AMI. Setting the filter to `amzn2-ami-hvm-2.0.20200207.1-x86_64-ebs` will allow you to version lock the target AMI if needed.
-
-The Runner uses a token to register with GitLab. This token is stored in the AWS SSM parameter store. The token has to be created
-manually in GitLab and stored in the SSM parameter store. All other registration methods are deprecated and will be removed in
-v8.0.0.
 
 ## Install the module
 

--- a/variables.tf
+++ b/variables.tf
@@ -358,18 +358,18 @@ variable "runner_cloudwatch" {
 }
 
 variable "runner_gitlab_registration_config" {
-  description = "(deprecated, replaced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
+  description = "(deprecated, replaced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Register the Runner manually with GitLab first."
   type = object({
-    registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__") # deprecated, removed in 8.0.0
-    tag_list           = optional(string, "")                                       # deprecated, removed in 8.0.0
-    description        = optional(string, "")                                       # deprecated, removed in 8.0.0
-    type               = optional(string, "")                                       # mandatory if gitlab_runner_version >= 16.0.0 # deprecated, removed in 8.0.0
-    group_id           = optional(string, "")                                       # mandatory if type is group # deprecated, removed in 8.0.0
-    project_id         = optional(string, "")                                       # mandatory if type is project # deprecated, removed in 8.0.0
-    locked_to_project  = optional(string, "")                                       # deprecated, removed in 8.0.0
-    run_untagged       = optional(string, "")                                       # deprecated, removed in 8.0.0
-    maximum_timeout    = optional(string, "")                                       # deprecated, removed in 8.0.0
-    access_level       = optional(string, "not_protected")                          # this is the only mandatory field calling the GitLab get token for executor operation # deprecated, removed in 8.0.0
+    registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__") # deprecated, do not use, will be removed
+    tag_list           = optional(string, "")                                       # deprecated, do not use, will be removed
+    description        = optional(string, "")                                       # deprecated, do not use, will be removed
+    type               = optional(string, "")                                       # deprecated, do not use, will be removed
+    group_id           = optional(string, "")                                       # deprecated, do not use, will be removed
+    project_id         = optional(string, "")                                       # deprecated, do not use, will be removed
+    locked_to_project  = optional(string, "")                                       # deprecated, do not use, will be removed
+    run_untagged       = optional(string, "")                                       # deprecated, do not use, will be removed
+    maximum_timeout    = optional(string, "")                                       # deprecated, do not use, will be removed
+    access_level       = optional(string, "not_protected")                          # deprecated, do not use, will be removed
   })
 
   default = {}
@@ -385,21 +385,21 @@ variable "runner_gitlab" {
   description = <<-EOT
     ca_certificate = Trusted CA certificate bundle (PEM format).
     certificate = Certificate of the GitLab instance to connect to (PEM format).
-    registration_token = (deprecated, This is replaced by the `registration_token` in `runner_gitlab_registration_config`.) Registration token to use to register the Runner.
+    registration_token = (deprecated, this is replaced by the `preregistered_runner_token_ssm_parameter_name`) Registration token to use to register the Runner.
     runner_version = Version of the [GitLab Runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases). Make sure that it is available for your AMI. See https://packages.gitlab.com/app/runner/gitlab-runner/search?dist=amazon%2F2023&filter=rpms&page=1&q=
     url = URL of the GitLab instance to connect to.
     url_clone = URL of the GitLab instance to clone from. Use only if the agent can’t connect to the GitLab URL.
-    access_token_secure_parameter_store_name = (deprecated) The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
+    access_token_secure_parameter_store_name = (deprecated, this is replaced by the `preregistered_runner_token_ssm_parameter_name`) The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
     preregistered_runner_token_ssm_parameter_name = The name of the SSM parameter to read the preregistered GitLab Runner token from.
   EOT
   type = object({
     ca_certificate                                = optional(string, "")
     certificate                                   = optional(string, "")
-    registration_token                            = optional(string, "__REPLACED_BY_USER_DATA__") # deprecated, removed in 8.0.0
+    registration_token                            = optional(string, "__REPLACED_BY_USER_DATA__") # deprecated, do not use, will be removed
     runner_version                                = optional(string, "16.0.3")
     url                                           = optional(string, "")
     url_clone                                     = optional(string, "")
-    access_token_secure_parameter_store_name      = optional(string, "gitlab-runner-access-token") # deprecated, removed in 8.0.0
+    access_token_secure_parameter_store_name      = optional(string, "gitlab-runner-access-token") # deprecated, do not use, will be removed
     preregistered_runner_token_ssm_parameter_name = optional(string, "")
   })
 }


### PR DESCRIPTION
## Description

- removes the `removed with 8.0.0` stuff which is wrong. The code is still there, but the current version is 9.3.0
- clearly state that the only option to register a Runner is using the `preregistered_runner_token_ssm_parameter_name`.

Closes #1301