### PR TITLE
fix: ensure that key pair names do not overlap

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,11 @@ variable "iam_permissions_boundary" {
 variable "environment" {
   description = "A name that identifies the environment, used as prefix and for tagging."
   type        = string
+
+  validation {
+    condition     = !startswith(var.environment, "runner-")
+    error_message = "Environment name cannot begin with 'runner-' because it breaks the naming convention for ssh key pairs within the terminate-agent-hook lambda function."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
## Description

Add a validation check to `var.environment` to make sure that we can't use `runner-` as prefix. If this prefix is used, the terminate agent lambda removes key pairs which shouldn't be removed. See https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/1291#issuecomment-3220317511

Closes #1291 
