### PR TITLE
chore: update kms settings for launch template to allow default kms

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "this" {
       iops        = contains(["gp3", "io1", "io2"], var.runner_worker_docker_autoscaler_instance.volume_type) ? var.runner_worker_docker_autoscaler_instance.volume_iops : null
       throughput  = var.runner_worker_docker_autoscaler_instance.volume_type == "gp3" ? var.runner_worker_docker_autoscaler_instance.volume_throughput : null
       encrypted   = true
-      kms_key_id = local.kms_key_arn != "" ? local.kms_key_arn : null
+      kms_key_id  = local.kms_key_arn != "" ? local.kms_key_arn : null
     }
   }
 


### PR DESCRIPTION
## Description

Fix for change in kms_key_id validation on the launch template ebs volumes. This was implemented on the aws provider 6.16.0 https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6160-october-9-2025. When using the default ebs kms key, it will now no longer complain about the empty "" provided to the kms_key_id for ebs volumes with encryption enabled.

```
│ Error: "block_device_mappings.0.ebs.0.kms_key_id" cannot be shorter than 1 character
│ 
│   with module.runner.aws_launch_template.this[0],
│   on .terraform/modules/runner/docker_autoscaler.tf line 41, in resource "aws_launch_template" "this":
│   41:       kms_key_id  = local.kms_key_arn
│ 
```

Closes #1342