### PR TITLE
feat: add `preemptive_mode` option passthrough on docker_autoscaler

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1164,7 +1164,7 @@ variable "runner_worker_docker_autoscaler_autoscaling_options" {
     idle_time          = optional(string)
     scale_factor       = optional(number)
     scale_factor_limit = optional(number, 0)
-    preemptive_mode    = optional(bool, true)
+    preemptive_mode    = optional(bool)
   }))
   default = []
 }


### PR DESCRIPTION
## Description

Allow passthrough of the preemptive_mode value on the runner_worker_docker_autoscaler_autoscaling_options as described on the doc that is linked on the code https://docs.gitlab.com/runner/configuration/advanced-configuration/#the-runnersautoscalerpolicy-sections

Should resolve the error on the message logs

`gitlab-runner: jsonschema: '/runners/0/Autoscaler/Policy/0/PreemptiveMode' does not validate with https://gitlab.com/gitlab-org/gitlab-runner/common/config#/$ref/properties/runners/items/$ref/properties/Autoscaler/$ref/properties/Policy/items/$ref/properties/PreemptiveMode/type: expected boolean, but got null`
## Verification

Ive confirmed this by adding the preemptive_mode value on the runner_worker_docker_autoscaler_autoscaling_options properties and confirmed by enabled the "debug_write_runner_config_to_file = true" to see it being added on the runners autoscaler policy

```
#module 
runner_worker_docker_autoscaler_autoscaling_options = [
  {
    periods      = ["* 7-19 * * mon-fri"]
    timezone     = "Europe/Amsterdam"
    idle_count   = 0
    idle_time    = "30m"
    scale_factor = 5
    preemptive_mode = true
  }
```


```
#toml
[[runners.autoscaler.policy]]
  idle_count = 0
  idle_time = "30m"
  periods = ["* 7-19 * * mon-fri"]
  **preemptive_mode = true**
  scale_factor = 5
  scale_factor_limit = 0
  timezone = "Europe/Amsterdam"
```
