### PR TITLE
fix: correct default terminate lambda handler value

### DIFF
--- a/modules/terminate-agent-hook/locals.tf
+++ b/modules/terminate-agent-hook/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  original_lambda_handler = "lambda_function.handler"
+  original_lambda_handler = "terminate_runners.handler"
   lambda_handler          = var.lambda_handler != null ? var.lambda_handler : local.original_lambda_handler
 
   replaced_environment_variables = { for key, value in var.environment_variables : key => replace(value, "{HANDLER}", local.original_lambda_handler) }


### PR DESCRIPTION
## Description

Fixes https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/1346

Terminate Lambda is not running due to wrong handler name.

## Verification
Trigger instance termination to run lambda to check it runs again properly.

