### PR TITLE
chore: handle Python 3.9 in GitLab runner startup script (fix #1370)

### DIFF
--- a/template/eip.tftpl
+++ b/template/eip.tftpl
@@ -1,7 +1,14 @@
 echo 'installing additional software for assigning EIP'
 
 yum install python3 -y
-curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
+
+# Check if Python version is 3.9, or greater
+if python3 -c 'import sys; exit(0) if sys.version_info >= (3, 10) else exit(1)'; then
+  curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
+else
+  curl --fail --retry 6 -O https://bootstrap.pypa.io/pip/3.9/get-pip.py
+fi
+
 python3 get-pip.py --user
 export PATH=~/.local/bin:$PATH
 


### PR DESCRIPTION
## Description

For users on the standard EC2 AMI, the default Python version is 3.9. This causes the `eip.tftpl` startup script to fail when running the `https://bootstrap.pypa.io/get-pip.py` script, as it was updated on May 4th, to require Python >= 3.10.

While it's not ideal to support a EOL Python version, we don't have much of a choice because of how the get-pip script works, and how the standard AWS AMIs work. 

Ideally, we'd just update the default Python version, however this will apparently break other things reliant on 3.9

<img width="977" height="259" alt="image" src="https://github.com/user-attachments/assets/e0c8d02b-19bf-4bae-8468-2255bc9e78ac" />

See https://docs.aws.amazon.com/linux/al2023/ug/python.html

## Migrations required

No

## Verification

I ran a build on our EC2 runners, with my changes, and it worked as expected.

System log output, from the code on this PR

```
ip-10-1-2-141 login: <13>May 13 15:41:48 user-data: Amazon Linux 2023 Kernel Livepatch repository   332 kB/s |  38 kB     00:00    
<13>May 13 15:41:49 user-data: Last metadata expiration check: 0:00:01 ago on Wed May 13 15:41:48 2026.
<13>May 13 15:41:50 user-data: Package python3-3.9.25-1.amzn2023.0.5.x86_64 is already installed.
<13>May 13 15:41:50 user-data: Dependencies resolved.
<13>May 13 15:41:50 user-data: Nothing to do.
<13>May 13 15:41:50 user-data: Complete!
<13>May 13 15:41:50 user-data:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
<13>May 13 15:41:50 user-data:                                  Dload  Upload   Total   Spent    Left  Speed
<13>May 13 15:41:50 user-data: 
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  2142k 100  2142k   0     0 16121k     0  --:--:-- --:--:-- --:--:-- 16227k
<13>May 13 15:41:53 user-data: Collecting pip<26.1
<13>May 13 15:41:53 user-data:   Downloading pip-26.0.1-py3-none-any.whl.metadata (4.7 kB)
<13>May 13 15:41:53 user-data: Collecting wheel
<13>May 13 15:41:53 user-data:   Downloading wheel-0.47.0-py3-none-any.whl.metadata (2.3 kB)
<13>May 13 15:41:53 user-data: Collecting packaging>=24.0 (from wheel)
<13>May 13 15:41:53 user-data:   Downloading packaging-26.2-py3-none-any.whl.metadata (3.5 kB)
<13>May 13 15:41:53 user-data: Downloading pip-26.0.1-py3-none-any.whl (1.8 MB)
<13>May 13 15:41:53 user-data:    ââââââââââââââââââââââââââââââââââââââââ 1.8/1.8 MB 56.8 MB/s  0:00:00
<13>May 13 15:41:53 user-data: Downloading wheel-0.47.0-py3-none-any.whl (32 kB)
<13>May 13 15:41:53 user-data: Downloading packaging-26.2-py3-none-any.whl (100 kB)
<13>May 13 15:41:53 user-data: Installing collected packages: pip, packaging, wheel
<13>May 13 15:41:54 user-data:   WARNING: The scripts pip, pip3 and pip3.9 are installed in '/root/.local/bin' which is not on PATH.
<13>May 13 15:41:54 user-data:   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
<13>May 13 15:41:54 user-data:   WARNING: The script wheel is installed in '/root/.local/bin' which is not on PATH.
<13>May 13 15:41:54 user-data:   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
<13>May 13 15:41:54 user-data: 
<13>May 13 15:41:54 user-data: Successfully installed packaging-26.2 pip-26.0.1 wheel-0.47.0
<13>May 13 15:41:54 user-data: WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
<13>May 13 15:41:55 user-data: Collecting aws-ec2-assign-elastic-ip
<13>May 13 15:41:55 user-data:   Downloading aws-ec2-assign-elastic-ip-0.10.2.tar.gz (9.5 kB)
<13>May 13 15:41:55 user-data:   Installing build dependencies: started
<13>May 13 15:41:56 user-data:   Installing build dependencies: finished with status 'done'
<13>May 13 15:41:56 user-data:   Getting requirements to build wheel: started
<13>May 13 15:41:56 user-data:   Getting requirements to build wheel: finished with status 'done'
<13>May 13 15:41:56 user-data:   Preparing metadata (pyproject.toml): started
<13>May 13 15:41:56 user-data:   Preparing metadata (pyproject.toml): finished with status 'done'
<13>May 13 15:41:57 user-data: Collecting boto3>=1.0.0 (from aws-ec2-assign-elastic-ip)
<13>May 13 15:41:57 user-data:   Downloading boto3-1.42.97-py3-none-any.whl.metadata (6.7 kB)
<13>May 13 15:41:57 user-data: Collecting netaddr>=0.7.12 (from aws-ec2-assign-elastic-ip)
<13>May 13 15:41:57 user-data:   Downloading netaddr-1.3.0-py3-none-any.whl.metadata (5.0 kB)
<13>May 13 15:41:57 user-data: Collecting ec2-metadata>=1.8.0 (from aws-ec2-assign-elastic-ip)
<13>May 13 15:41:57 user-data:   Downloading ec2_metadata-2.17.0-py3-none-any.whl.metadata (19 kB)
<13>May 13 15:41:57 user-data: Collecting botocore<1.43.0,>=1.42.97 (from boto3>=1.0.0->aws-ec2-assign-elastic-ip)
<13>May 13 15:41:57 user-data:   Downloading botocore-1.42.97-py3-none-any.whl.metadata (5.9 kB)
<13>May 13 15:41:57 user-data: Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in ./usr/lib/python3.9/site-packages (from boto3>=1.0.0->aws-ec2-assign-elastic-ip) (0.10.0)
<13>May 13 15:41:57 user-data: Collecting s3transfer<0.17.0,>=0.16.0 (from boto3>=1.0.0->aws-ec2-assign-elastic-ip)
<13>May 13 15:41:57 user-data:   Downloading s3transfer-0.16.1-py3-none-any.whl.metadata (1.7 kB)
<13>May 13 15:41:57 user-data: Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in ./usr/lib/python3.9/site-packages (from botocore<1.43.0,>=1.42.97->boto3>=1.0.0->aws-ec2-assign-elastic-ip) (2.8.1)
<13>May 13 15:41:57 user-data: Requirement already satisfied: urllib3<1.27,>=1.25.4 in ./usr/lib/python3.9/site-packages (from botocore<1.43.0,>=1.42.97->boto3>=1.0.0->aws-ec2-assign-elastic-ip) (1.25.10)
<13>May 13 15:41:57 user-data: Requirement already satisfied: six>=1.5 in ./usr/lib/python3.9/site-packages (from python-dateutil<3.0.0,>=2.1->botocore<1.43.0,>=1.42.97->boto3>=1.0.0->aws-ec2-assign-elastic-ip) (1.15.0)
<13>May 13 15:41:57 user-data: Requirement already satisfied: requests in ./usr/lib/python3.9/site-packages (from ec2-metadata>=1.8.0->aws-ec2-assign-elastic-ip) (2.25.1)
<13>May 13 15:41:57 user-data: Requirement already satisfied: chardet<5,>=3.0.2 in ./usr/lib/python3.9/site-packages (from requests->ec2-metadata>=1.8.0->aws-ec2-assign-elastic-ip) (4.0.0)
<13>May 13 15:41:57 user-data: Requirement already satisfied: idna<3,>=2.5 in ./usr/lib/python3.9/site-packages (from requests->ec2-metadata>=1.8.0->aws-ec2-assign-elastic-ip) (2.10)
<13>May 13 15:41:57 user-data: Downloading boto3-1.42.97-py3-none-any.whl (140 kB)
<13>May 13 15:41:57 user-data: Downloading botocore-1.42.97-py3-none-any.whl (15.0 MB)
<13>May 13 15:41:57 user-data:    ââââââââââââââââââââââââââââââââââââââââ 15.0/15.0 MB 174.9 MB/s  0:00:00
<13>May 13 15:41:57 user-data: Downloading s3transfer-0.16.1-py3-none-any.whl (86 kB)
<13>May 13 15:41:57 user-data: Downloading ec2_metadata-2.17.0-py3-none-any.whl (11 kB)
<13>May 13 15:41:57 user-data: Downloading netaddr-1.3.0-py3-none-any.whl (2.3 MB)
<13>May 13 15:41:57 user-data:    ââââââââââââââââââââââââââââââââââââââââ 2.3/2.3 MB 138.8 MB/s  0:00:00
<13>May 13 15:41:58 user-data: Building wheels for collected packages: aws-ec2-assign-elastic-ip
<13>May 13 15:41:58 user-data:   Building wheel for aws-ec2-assign-elastic-ip (pyproject.toml): started
<13>May 13 15:41:58 user-data:   Building wheel for aws-ec2-assign-elastic-ip (pyproject.toml): finished with status 'done'
<13>May 13 15:41:58 user-data:   Created wheel for aws-ec2-assign-elastic-ip: filename=aws_ec2_assign_elastic_ip-0.10.2-py3-none-any.whl size=10200 sha256=d92660347d9ba5e441c7a26d8106e97a96de22baff414c943603cdfdd87e235b
<13>May 13 15:41:58 user-data:   Stored in directory: /root/.cache/pip/wheels/03/79/88/42a0aade165db55f2962a91fca478f02e5f345039281906fd5
<13>May 13 15:41:58 user-data: Successfully built aws-ec2-assign-elastic-ip
<13>May 13 15:41:58 user-data: Installing collected packages: netaddr, ec2-metadata, botocore, s3transfer, boto3, aws-ec2-assign-elastic-ip
<13>May 13 15:41:59 user-data: 
<13>May 13 15:41:59 user-data: Successfully installed aws-ec2-assign-elastic-ip-0.10.2 boto3-1.42.97 botocore-1.42.97 ec2-metadata-2.17.0 netaddr-1.3.0 s3transfer-0.16.1
<13>May 13 15:41:59 user-data: WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
<13>May 13 15:41:59 user-data: /usr/local/lib/python3.9/site-packages/boto3/compat.py:89: PythonDeprecationWarning: Boto3 will no longer support Python 3.9 starting April 29, 2026. To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.10 or later. More information can be found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
<13>May 13 15:41:59 user-data:   warnings.warn(warning, PythonDeprecationWarning)
<13>May 13 15:41:59 user-data: 2026-05-13 15:41:59,968 - aws-ec2-assign-eip - INFO - Connected to AWS EC2 in us-west-2
..... // Rest of build log
```

Fixes https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/1370