### PR TITLE
ci: replace TfSec by Trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,16 +94,3 @@ jobs:
       - name: Run TFLint
         # assign necessary variables to avoid errors
         run: 'tflint --var ''enable_managed_kms_key=true'' --var=''runner_instance={"name_prefix": "a", "name": "b"}'''
-
-  tfsec:
-    name: tfsec PR commenter
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@7a44c5dcde5dfab737363e391800629e27b6376b # v1.3.1
-        with:
-          github_token: ${{ github.token }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           format: sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: tfsec
+name: trivy
 
 on:
   push:
@@ -14,8 +9,8 @@ on:
 permissions: read-all
 
 jobs:
-  tfsec:
-    name: tfsec sarif report
+  trivy:
+    name: trivy sarif report
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -28,13 +23,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: tfsec
-        uses: aquasecurity/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608 # v0.1.4
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0
         with:
-          sarif_file: tfsec.sarif
+          scan-type: config
+          format: sarif
+          output: trivy.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: tfsec.sarif
+          sarif_file: trivy.sarif


### PR DESCRIPTION
TfSec is outdated. The successor is Tricvy which is introduced by this PR.