### PR TITLE
fix: replace deprecated npalm/action-app-token with actions/create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,11 @@ jobs:
         run: |
           PRIVATE_KEY=$(echo '${{ secrets.RELEASER_APP_PRIVATE_KEY_BASE64 }}' | base64 --decode)
           echo "::add-mask::$PRIVATE_KEY"
-          echo "key<<EOF" >> $GITHUB_OUTPUT
-          echo "$PRIVATE_KEY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "key<<EOF"
+            echo "$PRIVATE_KEY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Get app installation token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Get app installation token
-        uses: npalm/action-app-token@dd4bb16d91ced5659bc618705c96b822c5a42136 # ratchet:npalm/action-app-token@v1.1.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: token
         with:
-          appId: ${{ secrets.RELEASER_APP_ID }}
-          appPrivateKeyBase64: ${{ secrets.RELEASER_APP_PRIVATE_KEY_BASE64 }}
-          appInstallationType: repo
-          appInstallationValue: ${{ github.repository }}
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ fromBase64(secrets.RELEASER_APP_PRIVATE_KEY_BASE64) }}
       # bootstrap-sha and release-as needs to be removed after first release
       - name: Release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,20 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Decode app private key
+        id: decode-key
+        run: |
+          PRIVATE_KEY=$(echo '${{ secrets.RELEASER_APP_PRIVATE_KEY_BASE64 }}' | base64 --decode)
+          echo "::add-mask::$PRIVATE_KEY"
+          echo "key<<EOF" >> $GITHUB_OUTPUT
+          echo "$PRIVATE_KEY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Get app installation token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: token
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
-          private-key: ${{ fromBase64(secrets.RELEASER_APP_PRIVATE_KEY_BASE64) }}
+          private-key: ${{ steps.decode-key.outputs.key }}
       # bootstrap-sha and release-as needs to be removed after first release
       - name: Release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+  workflow_dispatch: # temporary: for testing the fix on the PR branch
 
 permissions: read-all
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-  workflow_dispatch: # temporary: for testing the fix on the PR branch
 
 permissions: read-all
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: token
         with:
-          app-id: ${{ secrets.RELEASER_APP_ID }}
+          client-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ steps.decode-key.outputs.key }}
       # bootstrap-sha and release-as needs to be removed after first release
       - name: Release


### PR DESCRIPTION
## Problem

The release job has been failing with:

> release-please failed: Requires authentication

### Root cause

The workflow used `npalm/action-app-token@v1.1.0` to generate a GitHub App installation token. This action internally used the `set-output` workflow command to expose the token as a step output.

GitHub [deprecated and then disabled the `set-output` command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in favour of writing to the `GITHUB_OUTPUT` environment file. Once disabled, the command silently does nothing - meaning `steps.token.outputs.token` was always empty. The `release-please` step then received no token and failed with an authentication error.

`npalm/action-app-token` is effectively unmaintained (last release: October 2022, same month the command was deprecated) and will never be fixed.

## Fix

Replace `npalm/action-app-token` with [`actions/create-github-app-token@v3.2.0`](https://github.com/actions/create-github-app-token), the official GitHub-maintained action for generating GitHub App tokens. It uses the modern `GITHUB_OUTPUT` environment file and is actively maintained.

### Why the extra decode step?

The existing secret `RELEASER_APP_PRIVATE_KEY_BASE64` stores the private key base64-encoded. The new action expects a raw PEM key via its `private-key` input - it has no built-in base64 support, and `fromBase64()` is not a GitHub Actions expression function.

To avoid requiring a secret change, a decode step is added that:
1. Decodes the base64 secret with `base64 --decode`
2. Immediately masks the decoded PEM value from logs with `::add-mask::` to prevent accidental exposure
3. Passes it to the action via `GITHUB_OUTPUT`

No secrets need to be rotated or changed.

## Verification

The fix was tested by temporarily adding `workflow_dispatch` to the workflow and triggering it manually on this branch. The run completed successfully: https://github.com/cattle-ops/terraform-aws-gitlab-runner/actions/runs/27340646442