### PR TITLE
fix: expose on_demand_allocation_strategy to unblock instance_requirements

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -98,6 +98,7 @@ resource "aws_autoscaling_group" "autoscaler" {
 
     content {
       instances_distribution {
+        on_demand_allocation_strategy            = var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy
         on_demand_base_capacity                  = var.runner_worker_docker_autoscaler_asg.on_demand_base_capacity
         on_demand_percentage_above_base_capacity = var.runner_worker_docker_autoscaler_asg.on_demand_percentage_above_base_capacity
         spot_allocation_strategy                 = var.runner_worker_docker_autoscaler_asg.spot_allocation_strategy

--- a/variables.tf
+++ b/variables.tf
@@ -813,7 +813,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     health_check_type = Controls how health checking is done. Values are - EC2 and ELB.
     instance_refresh_min_healthy_percentage = The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group.
     instance_refresh_triggers = Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy.
-    on_demand_allocation_strategy = Strategy for allocating on-demand instances. Valid values: 'prioritized' (by override order) or 'lowest-price'. Must be set to 'lowest-price' when instance_requirements is used — AWS rejects any other value with attribute-based instance selection. Defaults to null (AWS uses 'prioritized' when types are used).
+    on_demand_allocation_strategy = Strategy for allocating on-demand instances. Valid values: 'prioritized' (by override order) or 'lowest-price'. Must be 'lowest-price' when instance_requirements is used — AWS rejects any other value with attribute-based instance selection. Defaults to 'lowest-price'.
     on_demand_base_capacity = Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
     on_demand_percentage_above_base_capacity = Percentage split between on-demand and Spot instances above the base on-demand capacity.
     spot_allocation_strategy = How to allocate capacity across the Spot pools. 'lowest-price' to optimize cost, 'capacity-optimized' to reduce interruptions.
@@ -831,7 +831,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     health_check_type                        = optional(string, "EC2")
     instance_refresh_min_healthy_percentage  = optional(number, 90)
     instance_refresh_triggers                = optional(list(string), [])
-    on_demand_allocation_strategy            = optional(string, null)
+    on_demand_allocation_strategy            = optional(string, "lowest-price")
     on_demand_base_capacity                  = optional(number, 0)
     on_demand_percentage_above_base_capacity = optional(number, 100)
     spot_allocation_strategy                 = optional(string, "lowest-price")
@@ -861,8 +861,8 @@ variable "runner_worker_docker_autoscaler_asg" {
   }
 
   validation {
-    condition     = var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy == null || contains(["prioritized", "lowest-price"], var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy)
-    error_message = "on_demand_allocation_strategy must be 'prioritized', 'lowest-price', or null."
+    condition     = contains(["prioritized", "lowest-price"], var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy)
+    error_message = "on_demand_allocation_strategy must be 'prioritized' or 'lowest-price'."
   }
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -813,6 +813,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     health_check_type = Controls how health checking is done. Values are - EC2 and ELB.
     instance_refresh_min_healthy_percentage = The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group.
     instance_refresh_triggers = Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy.
+    on_demand_allocation_strategy = Strategy for allocating on-demand instances. Valid values: 'prioritized' (by override order) or 'lowest-price'. Must be set to 'lowest-price' when instance_requirements is used — AWS rejects any other value with attribute-based instance selection. Defaults to null (AWS uses 'prioritized' when types are used).
     on_demand_base_capacity = Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
     on_demand_percentage_above_base_capacity = Percentage split between on-demand and Spot instances above the base on-demand capacity.
     spot_allocation_strategy = How to allocate capacity across the Spot pools. 'lowest-price' to optimize cost, 'capacity-optimized' to reduce interruptions.
@@ -830,6 +831,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     health_check_type                        = optional(string, "EC2")
     instance_refresh_min_healthy_percentage  = optional(number, 90)
     instance_refresh_triggers                = optional(list(string), [])
+    on_demand_allocation_strategy            = optional(string, null)
     on_demand_base_capacity                  = optional(number, 0)
     on_demand_percentage_above_base_capacity = optional(number, 100)
     spot_allocation_strategy                 = optional(string, "lowest-price")
@@ -856,6 +858,16 @@ variable "runner_worker_docker_autoscaler_asg" {
   validation {
     condition     = length(var.runner_worker_docker_autoscaler_asg.types) == 0 || length(var.runner_worker_docker_autoscaler_asg.instance_requirements) == 0
     error_message = "AWS does not allow setting both 'types' and 'instance_requirements' at the same time. Set only one."
+  }
+
+  validation {
+    condition     = var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy == null || contains(["prioritized", "lowest-price"], var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy)
+    error_message = "on_demand_allocation_strategy must be 'prioritized', 'lowest-price', or null."
+  }
+
+  validation {
+    condition     = length(var.runner_worker_docker_autoscaler_asg.instance_requirements) == 0 || var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy == "lowest-price"
+    error_message = "on_demand_allocation_strategy must be set to 'lowest-price' when instance_requirements is used — AWS rejects any other value with attribute-based instance selection."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -816,7 +816,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     on_demand_allocation_strategy = Strategy for allocating on-demand instances. Valid values: 'prioritized' (by override order) or 'lowest-price'. Must be 'lowest-price' when instance_requirements is used — AWS rejects any other value with attribute-based instance selection. Defaults to 'lowest-price'.
     on_demand_base_capacity = Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
     on_demand_percentage_above_base_capacity = Percentage split between on-demand and Spot instances above the base on-demand capacity.
-    spot_allocation_strategy = How to allocate capacity across the Spot pools. 'lowest-price' to optimize cost, 'capacity-optimized' to reduce interruptions.
+    spot_allocation_strategy = How to allocate capacity across the Spot pools. 'lowest-price' to optimize cost, 'capacity-optimized' to reduce interruptions, 'price-capacity-optimized' to balance both price and capacity availability (recommended for most workloads).
     spot_instance_pools = Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify.
     subnet_ids = The list of subnet IDs to use for the Runner Worker when the fleet mode is enabled.
     default_instance_type = Default instance type for the launch template
@@ -858,11 +858,6 @@ variable "runner_worker_docker_autoscaler_asg" {
   validation {
     condition     = length(var.runner_worker_docker_autoscaler_asg.types) == 0 || length(var.runner_worker_docker_autoscaler_asg.instance_requirements) == 0
     error_message = "AWS does not allow setting both 'types' and 'instance_requirements' at the same time. Set only one."
-  }
-
-  validation {
-    condition     = contains(["prioritized", "lowest-price"], var.runner_worker_docker_autoscaler_asg.on_demand_allocation_strategy)
-    error_message = "on_demand_allocation_strategy must be 'prioritized' or 'lowest-price'."
   }
 
   validation {


### PR DESCRIPTION
`instance_requirements` (attribute-based instance selection) was already supported
by this module, but applying it would fail at the AWS API level with:

> ValidationError: The specified OnDemandAllocationStrategy is not valid.
> The prioritized allocation strategy is not compatible with instance requirements.
> Valid options are [lowest-price].

This happened because `on_demand_allocation_strategy` was not exposed by the module,
so AWS defaulted to `prioritized`, which it rejects when `instance_requirements` is used.

## Changes

- Add `on_demand_allocation_strategy` to `runner_worker_docker_autoscaler_asg` and
  pass it through to the ASG `instances_distribution` block
- Default to `lowest-price`, consistent with the existing `spot_allocation_strategy` default
- Add a validation that enforces `lowest-price` when `instance_requirements` is set,
  surfacing a clear `terraform validate` error instead of a misleading AWS 400 at apply time

## Usage

To use attribute-based instance selection:

```hcl
runner_worker_docker_autoscaler_asg = {
  enable_mixed_instances_policy = true
  on_demand_allocation_strategy = "lowest-price"
  instance_requirements = [{
    vcpu_count            = { min = 4, max = 16 }
    memory_mib            = { min = 16384, max = null }
    cpu_manufacturers     = ["amazon-web-services"]
    instance_generations  = ["current"]
    burstable_performance = "excluded"
  }]
}
