### PR TITLE
feat: support additional_tags on worker launch template

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -44,15 +44,15 @@ resource "aws_launch_template" "this" {
 
   tag_specifications {
     resource_type = "instance"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
   tag_specifications {
     resource_type = "volume"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
   tag_specifications {
     resource_type = "network-interface"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
 
   tags = local.tags

--- a/tags.tf
+++ b/tags.tf
@@ -39,4 +39,6 @@ locals {
   runner_tags_string = join(",", flatten([
     for key in keys(local.runner_tags) : [key, local.runner_tags[key]]
   ]))
+
+  worker_tags = merge(local.tags, var.runner_worker_docker_autoscaler_instance.additional_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -780,6 +780,7 @@ variable "runner_worker_docker_autoscaler_instance" {
     volume_type = The type of volume to use for the Runner Worker. `gp2`, `gp3`, `io1` or `io2` are supported.
     volume_iops = Guaranteed IOPS for the volume. Only supported when using `gp3`, `io1` or `io2` as `volume_type`.
     volume_throughput = Throughput in MB/s for the volume. Only supported when using `gp3` as `volume_type`.
+    additional_tags = Additional tags to apply exclusively to the worker launch template's tag_specifications (instance, volume, network-interface). These do not affect the runner manager.
 EOT
 
   type = object({
@@ -796,6 +797,7 @@ EOT
     volume_type                        = optional(string, "gp2")
     volume_throughput                  = optional(number, 125)
     volume_iops                        = optional(number, 3000)
+    additional_tags                    = optional(map(string), {})
   })
   default = {}
 


### PR DESCRIPTION
## Summary

Adds an `additional_tags` field to `runner_worker_docker_autoscaler_instance` that applies tags exclusively to the worker launch template's `tag_specifications` (instance, volume, network-interface) without affecting the runner manager instance.

This enables use cases like excluding ephemeral CI workers from AWS GuardDuty Runtime Monitoring while keeping the manager monitored.

### Usage

```hcl
runner_worker_docker_autoscaler_instance = {
  additional_tags = { "GuardDutyManaged" = "false" }
}
```

Closes #1369

## Changes

- `variables.tf`: Add `additional_tags = optional(map(string), {})` to the `runner_worker_docker_autoscaler_instance` object
- `tags.tf`: Add `worker_tags` local that merges `local.tags` with the new `additional_tags`
- `docker_autoscaler.tf`: Use `local.worker_tags` in `tag_specifications` blocks

🤖 Generated with Claude Code