### PR TITLE
feat: expose health_check_type for runner manager ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,8 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
   min_size                  = "1"
   max_size                  = "1"
   desired_capacity          = "1"
-  health_check_grace_period = 0
+  health_check_grace_period = var.runner_instance.health_check_grace_period
+  health_check_type         = var.runner_instance.health_check_type
   max_instance_lifetime     = var.runner_instance.max_lifetime_seconds
   enabled_metrics           = var.runner_instance.collect_autoscaling_metrics
 

--- a/variables.tf
+++ b/variables.tf
@@ -119,12 +119,16 @@ variable "runner_instance" {
     spot_price = By setting a spot price bid price the Runner is created via a spot request. Be aware that spot instances can be stopped by AWS. Choose \"on-demand-price\" to pay up to the current on demand price for the instance type chosen.
     ssm_access = Allows to connect to the Runner via SSM.
     type = EC2 instance type used.
+    health_check_type = The health check type for the Runner manager ASG. Valid values are "EC2" or "ELB". When set to "ELB", attach a target group to the ASG and configure an application-level health check (e.g. the Prometheus /metrics endpoint on port 9252).
+    health_check_grace_period = Time in seconds after instance comes into service before checking health. Only relevant when health_check_type is "ELB".
     use_eip = Assigns an EIP to the Runner.
   EOT
   type = object({
     additional_tags             = optional(map(string))
     collect_autoscaling_metrics = optional(list(string), null)
     ebs_optimized               = optional(bool, true)
+    health_check_grace_period   = optional(number, 0)
+    health_check_type           = optional(string, "EC2")
     max_lifetime_seconds        = optional(number, null)
     monitoring                  = optional(bool, true)
     name                        = string


### PR DESCRIPTION
## Summary

- Adds `health_check_type` and `health_check_grace_period` to the `runner_instance` variable
- Wires them into the `aws_autoscaling_group.gitlab_runner_instance` resource
- Defaults unchanged: `"EC2"` health check type, `0` grace period

## Motivation

The runner manager ASG uses EC2 health checks, which only detect hardware-level failures. OS-level freezes (OOM, kernel panic that doesn't trigger instance stop, EBS I/O stalls) leave the instance appearing healthy from the hypervisor's perspective while all userspace processes are dead.

With this change, users can attach a target group pointing at the gitlab-runner Prometheus endpoint (`:9252/metrics`) and set `health_check_type = "ELB"` to get automatic replacement of unresponsive manager instances.

## Usage

```hcl
runner_instance = {
  name              = "gitlab-runner"
  type              = "t4g.medium"
  health_check_type = "ELB"
  health_check_grace_period = 120
}
```

Combined with an ALB/NLB target group attached to the ASG.

## Test plan

- [ ] Verify `terraform plan` shows no changes when using defaults (`"EC2"`, `0`)
- [ ] Verify setting `health_check_type = "ELB"` propagates to the ASG resource

🤖 Generated with Claude Code