### PR TITLE
fix: allow DescribeLifecycleHooks for monitor_runner.sh

### DIFF
--- a/docker_autoscaler_policy.tf
+++ b/docker_autoscaler_policy.tf
@@ -20,6 +20,7 @@ resource "aws_iam_policy" "instance_docker_autoscaler_policy" {
       partition           = data.aws_partition.current.partition
       autoscaler_asg_arn  = aws_autoscaling_group.autoscaler[0].arn
       autoscaler_asg_name = aws_autoscaling_group.autoscaler[0].name
+      runner_asg_arn      = aws_autoscaling_group.gitlab_runner_instance.arn
   })
 
   tags = local.tags

--- a/policies/instance-docker-autoscaler-policy.json
+++ b/policies/instance-docker-autoscaler-policy.json
@@ -5,16 +5,22 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DescribeLifecycleHooks"
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
             "Resource": "${autoscaler_asg_arn}"
         },
         {
             "Effect": "Allow",
             "Action": [
+                "autoscaling:CompleteLifecycleAction"
+            ],
+            "Resource": "${runner_asg_arn}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLifecycleHooks",
                 "ec2:DescribeInstances",
                 "ec2:DescribeSpotInstanceRequests",
                 "ec2:DescribeTags"


### PR DESCRIPTION
Move autoscaling:DescribeLifecycleHooks to Resource "*" (describe APIs do not support resource-level permissions) and scope CompleteLifecycleAction to the Runner Manager ASG that the script actually targets, instead of the worker autoscaler ASG.

## Description

fixes an error with the graceful shutdown permissions - noticed in logs prevents graceful shutdown from finishing

```
An error occurred (AccessDenied) when calling the DescribeLifecycleHooks operation: User: arn:aws:sts::123456789:assumed-role/example-instance/i-XXXXXXXXXX is not authorized to perform: autoscaling:DescribeLifecycleHooks because no identity-based policy allows the autoscaling:DescribeLifecycleHooks action
```

## Migrations required

No

## Verification

Not done.