### PR TITLE
feat: support additional_tags on worker launch template

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -44,15 +44,15 @@ resource "aws_launch_template" "this" {
 
   tag_specifications {
     resource_type = "instance"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
   tag_specifications {
     resource_type = "volume"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
   tag_specifications {
     resource_type = "network-interface"
-    tags          = local.tags
+    tags          = local.worker_tags
   }
 
   tags = local.tags

--- a/tags.tf
+++ b/tags.tf
@@ -39,4 +39,6 @@ locals {
   runner_tags_string = join(",", flatten([
     for key in keys(local.runner_tags) : [key, local.runner_tags[key]]
   ]))
+
+  worker_tags = merge(local.tags, var.runner_worker_docker_autoscaler_instance.additional_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -780,6 +780,7 @@ variable "runner_worker_docker_autoscaler_instance" {
     volume_type = The type of volume to use for the Runner Worker. `gp2`, `gp3`, `io1` or `io2` are supported.
     volume_iops = Guaranteed IOPS for the volume. Only supported when using `gp3`, `io1` or `io2` as `volume_type`.
     volume_throughput = Throughput in MB/s for the volume. Only supported when using `gp3` as `volume_type`.
+    additional_tags = Additional tags to apply exclusively to the worker launch template's tag_specifications (instance, volume, network-interface). These do not affect the runner manager.
 EOT
 
   type = object({
@@ -796,6 +797,7 @@ EOT
     volume_type                        = optional(string, "gp2")
     volume_throughput                  = optional(number, 125)
     volume_iops                        = optional(number, 3000)
+    additional_tags                    = optional(map(string), {})
   })
   default = {}
 


### PR DESCRIPTION
Closes #1369

Supersedes #1383 — same commit, same author, only the head repository changed from a personal fork to our organisation's, so colleagues can push to the branch. #1383 is being closed in favour of this one.

## Summary

Adds an `additional_tags` field to `runner_worker_docker_autoscaler_instance` that applies tags exclusively to the worker launch template's `tag_specifications` (instance, volume, network-interface), without affecting the runner manager instance.

```hcl
runner_worker_docker_autoscaler_instance = {
  additional_tags = { "GuardDutyManaged" = "false" }
}
```

## Motivation

With the `docker-autoscaler` executor there is currently no way to tag workers without also tagging the manager. The top-level `tags` variable and the provider's `default_tags` propagate to everything, and `runner_instance.additional_tags` only reaches the manager ASG.

Our case is AWS GuardDuty Runtime Monitoring, which can skip instances tagged `GuardDutyManaged: false`. Scanning short-lived spot CI workers costs real money for little security value, while the long-lived manager should stay monitored. Today it is all or nothing.

## Changes

- `variables.tf` — `additional_tags = optional(map(string), {})` on the `runner_worker_docker_autoscaler_instance` object
- `tags.tf` — a `worker_tags` local merging `local.tags` with `additional_tags`
- `docker_autoscaler.tf` — `tag_specifications` use `local.worker_tags`

The launch template's own `tags` attribute deliberately stays on `local.tags`, since it describes the template rather than the instances launched from it.

## Compatibility

Defaults to `{}`, so existing configurations plan identically.

Verified against a two-runner production deployment (x86 + arm64, docker-autoscaler, mixed instances policy): with `additional_tags` unset the plan is unchanged; with it set, only the worker `tag_specifications` gain the tag while the manager launch template does not.

## Note for reviewers

If it helps, two refinements are available and easy to fold in: filtering the merged worker tags through `suppressed_tags` so the new field behaves like the existing `agent_tags` local rather than bypassing suppression, and regenerating the README variable table with `terraform-docs`. Happy to push either on request.
