### PR TITLE
fix: only create the autoscaler key pair when use_private_key is set

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -13,7 +13,7 @@ resource "aws_launch_template" "this" {
   user_data     = var.runner_worker_docker_autoscaler_instance.start_script_compression_algorithm == "gzip" ? base64gzip(var.runner_worker_docker_autoscaler_instance.start_script) : base64encode(var.runner_worker_docker_autoscaler_instance.start_script)
   image_id      = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_id : data.aws_ami.docker_autoscaler_by_filter[0].id
   instance_type = length(var.runner_worker_docker_autoscaler_asg.types) > 0 ? var.runner_worker_docker_autoscaler_asg.types[0] : var.runner_worker_docker_autoscaler_asg.default_instance_type
-  key_name      = aws_key_pair.autoscaler[0].key_name
+  key_name      = local.enable_autoscaler_key_pair ? aws_key_pair.autoscaler[0].key_name : null
   ebs_optimized = var.runner_worker_docker_autoscaler_instance.ebs_optimized
 
   monitoring {
@@ -190,14 +190,14 @@ resource "aws_iam_instance_profile" "docker_autoscaler" {
 }
 
 resource "tls_private_key" "autoscaler" {
-  count = var.runner_worker.type == "docker-autoscaler" ? 1 : 0
+  count = local.enable_autoscaler_key_pair ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = 4096
 }
 
 resource "aws_key_pair" "autoscaler" {
-  count = var.runner_worker.type == "docker-autoscaler" ? 1 : 0
+  count = local.enable_autoscaler_key_pair ? 1 : 0
 
   key_name   = "${var.environment}-${var.runner_worker_docker_autoscaler.key_pair_name}"
   public_key = tls_private_key.autoscaler[0].public_key_openssh

--- a/locals.tf
+++ b/locals.tf
@@ -97,6 +97,10 @@ locals {
   : var.runner_terminate_ec2_lifecycle_timeout_duration)
 
   kms_key_arn = local.provided_kms_key == "" && var.enable_managed_kms_key ? aws_kms_key.default[0].arn : local.provided_kms_key
+
+  # Without a key pair the manager reaches the workers through EC2 Instance Connect, which issues ephemeral keys per
+  # connection. Creating one anyway would leave a long-lived private key in the state and authorize it on every worker.
+  enable_autoscaler_key_pair = var.runner_worker.type == "docker-autoscaler" && var.runner_worker.use_private_key
 }
 
 resource "local_file" "config_toml" {

--- a/main.tf
+++ b/main.tf
@@ -86,9 +86,9 @@ locals {
       gitlab_runner_project_id                                     = var.runner_gitlab_registration_config["project_id"]
       gitlab_runner_access_level                                   = var.runner_gitlab_registration_config.access_level
       sentry_dsn                                                   = var.runner_manager.sentry_dsn
-      public_key                                                   = var.runner_worker.use_private_key && var.runner_worker.type == "docker-autoscaler" ? tls_private_key.autoscaler[0].public_key_openssh : var.runner_worker_docker_machine_fleet.enable == true ? tls_private_key.fleet[0].public_key_openssh : ""
-      private_key                                                  = var.runner_worker.use_private_key && var.runner_worker.type == "docker-autoscaler" ? tls_private_key.autoscaler[0].private_key_pem : var.runner_worker_docker_machine_fleet.enable == true ? tls_private_key.fleet[0].private_key_pem : ""
-      use_private_key                                              = var.runner_worker_docker_machine_fleet.enable || (var.runner_worker.use_private_key && var.runner_worker.type == "docker-autoscaler")
+      public_key                                                   = local.enable_autoscaler_key_pair ? tls_private_key.autoscaler[0].public_key_openssh : var.runner_worker_docker_machine_fleet.enable == true ? tls_private_key.fleet[0].public_key_openssh : ""
+      private_key                                                  = local.enable_autoscaler_key_pair ? tls_private_key.autoscaler[0].private_key_pem : var.runner_worker_docker_machine_fleet.enable == true ? tls_private_key.fleet[0].private_key_pem : ""
+      use_private_key                                              = var.runner_worker_docker_machine_fleet.enable || local.enable_autoscaler_key_pair
       use_new_fleeting_install                                     = local.runner_use_new_fleeting_install
       use_new_runner_authentication_gitlab_16                      = var.runner_gitlab_registration_config.type != ""
       user_data_trace_log                                          = var.debug.trace_runner_user_data


### PR DESCRIPTION
## Problem

For `docker-autoscaler`, `tls_private_key.autoscaler` and `aws_key_pair.autoscaler` are created whenever `runner_worker.type == "docker-autoscaler"`, and the worker launch template sets `key_name` unconditionally.

But the manager only ever uses that key when `runner_worker.use_private_key` is `true`, which is the non-default:

- `template/gitlab-runner.tftpl` writes `/root/.ssh/id_rsa` only under `if use_private_key`
- `template/runner-docker-autoscaler-config.tftpl` emits `key_path` only under the same condition

With the default `use_private_key = false`, the manager reaches its workers through EC2 Instance Connect — `ec2-instance-connect:SendSSHPublicKey` is already granted in `policies/instance-docker-autoscaler-policy.json`, and the plugin pushes an ephemeral key per connection.

So on a default `docker-autoscaler` setup the key pair is pure overhead, and not the harmless kind:

- a fresh RSA-4096 key pair is generated on every apply
- its private half is stored in Terraform state
- its public half is authorized for the connector user on every worker, with no holder

## Change

Gate the key pair and the launch template's `key_name` on the same condition that already gates `key_path`, via a new local:

```hcl
enable_autoscaler_key_pair = var.runner_worker.type == "docker-autoscaler" && var.runner_worker.use_private_key
```

`main.tf` already spelled that condition out three times for `public_key` / `private_key` / `use_private_key`, so those now reference the local too.

No variables change, and `use_private_key = true` behaves exactly as before.

## Upgrade impact

For anyone on `docker-autoscaler` with the default `use_private_key = false`, the plan destroys `aws_key_pair.autoscaler` and `tls_private_key.autoscaler` and updates the worker launch template in place to drop `key_name`. No replacements. Existing workers keep their current launch template version until they are cycled.

Verified on a production setup with two `docker-autoscaler` runners (x86 and arm64): `0 to add, 7 to change, 4 to destroy`, and jobs keep running over EC2 Instance Connect. Notably, Terraform reports the *manager* launch template's `user_data` as changed only in its sensitivity marking, with "The value is unchanged" — confirming the key never reached the manager in the first place.

Users who do want a static key pair set `use_private_key = true` and are unaffected.